### PR TITLE
Adding addHandlesToTrackItem() function to 3P Sample

### DIFF
--- a/sample-panels/3psample-panel/html/index.html
+++ b/sample-panels/3psample-panel/html/index.html
@@ -178,6 +178,10 @@
         <sp-button id="trim-selected-item">
           Trim First Selected TrackItem
         </sp-button>
+
+        <sp-button id="trim-handles">
+          Trim 1 second off Head and Tail of first selected TrackItem
+        </sp-button>
       </div>
       <div class="section">
         <h4>Markers</h4>

--- a/sample-panels/3psample-panel/html/index.html
+++ b/sample-panels/3psample-panel/html/index.html
@@ -180,7 +180,7 @@
         </sp-button>
 
         <sp-button id="trim-handles">
-          Trim 1 second off Head and Tail of first selected TrackItem
+          Trim 20 Frames Off Head and Tail of First Selected TrackItem
         </sp-button>
       </div>
       <div class="section">

--- a/sample-panels/3psample-panel/html/index.ts
+++ b/sample-panels/3psample-panel/html/index.ts
@@ -591,8 +591,8 @@ async function trimHandlesClicked(callback) {
   if (items.length > 0) {
     const trackItem_toChange = items[0];
 
-    var inPointOffset = -1;
-    var outPointOffset = -1;
+    var inPointOffset = -20;
+    var outPointOffset = -20;
 
     success = await addHandlesToTrackItem_usingTicks(project, sequence, trackItem_toChange, inPointOffset, outPointOffset);
   } else {

--- a/sample-panels/3psample-panel/html/index.ts
+++ b/sample-panels/3psample-panel/html/index.ts
@@ -42,6 +42,7 @@ import {
   setSequenceSelection,
   createSubsequence,
   trimSelectedItem,
+  addHandlesToTrackItem,
 } from "./src/sequence";
 
 import {
@@ -573,6 +574,36 @@ async function trimSelectedItemClicked() {
       ? "First selected trackItem is trimmed and shortened by 1s"
       : "Failed to trim selected trackItem at active sequence"
   );
+}
+
+async function trimHandlesClicked(callback) {
+  var success = false;
+  const project = await getProject();
+  if (!project) return;
+
+  const sequence = await getActiveSequence(project);
+
+  const selection = await sequence.getSelection();
+  const items: Array<VideoClipTrackItem | AudioClipTrackItem> =
+    await selection.getTrackItems();
+    
+  if (items.length > 0) {
+    const trackItem_toChange = items[0];
+
+    var inPointOffset = -1;
+    var outPointOffset = -1;
+
+    success = await addHandlesToTrackItem(project, trackItem_toChange, inPointOffset, outPointOffset);
+  } else {
+    log("No trackItem selected.", "red");
+    throw new Error("no trackItem is selected at sequence");
+  }
+
+  if (success){
+    log(`First trackItem handles were changed by ${inPointOffset} second(s) at head and ${outPointOffset} second(s) at the tail.`);
+  }else{
+    log("Failed to trim first selected trackItem.", "red");
+  }
 }
 
 //marker button events
@@ -1576,6 +1607,7 @@ window.addEventListener("load", async () => {
   registerClick("clone-selected-item", cloneSelectedItemClicked);
   registerClick("remove-selected-items", removeSelectedItemClicked);
   registerClick("trim-selected-item", trimSelectedItemClicked);
+  registerClick("trim-handles", trimHandlesClicked);
 
   //marker events registering
   registerClick("marker-comment", createMarkerCommentClicked);

--- a/sample-panels/3psample-panel/html/index.ts
+++ b/sample-panels/3psample-panel/html/index.ts
@@ -43,6 +43,7 @@ import {
   createSubsequence,
   trimSelectedItem,
   addHandlesToTrackItem,
+  addHandlesToTrackItem_usingTicks,
 } from "./src/sequence";
 
 import {
@@ -593,14 +594,14 @@ async function trimHandlesClicked(callback) {
     var inPointOffset = -1;
     var outPointOffset = -1;
 
-    success = await addHandlesToTrackItem(project, trackItem_toChange, inPointOffset, outPointOffset);
+    success = await addHandlesToTrackItem_usingTicks(project, sequence, trackItem_toChange, inPointOffset, outPointOffset);
   } else {
     log("No trackItem selected.", "red");
     throw new Error("no trackItem is selected at sequence");
   }
 
   if (success){
-    log(`First trackItem handles were changed by ${inPointOffset} second(s) at head and ${outPointOffset} second(s) at the tail.`);
+    log(`First trackItem handles were changed by ${inPointOffset} frame(s) at head and ${outPointOffset} frame(s) at the tail.`);
   }else{
     log("Failed to trim first selected trackItem.", "red");
   }

--- a/sample-panels/3psample-panel/html/index.ts
+++ b/sample-panels/3psample-panel/html/index.ts
@@ -43,7 +43,6 @@ import {
   createSubsequence,
   trimSelectedItem,
   addHandlesToTrackItem,
-  addHandlesToTrackItem_usingTicks,
 } from "./src/sequence";
 
 import {
@@ -594,7 +593,7 @@ async function trimHandlesClicked(callback) {
     var inPointOffset = -20;
     var outPointOffset = -20;
 
-    success = await addHandlesToTrackItem_usingTicks(project, sequence, trackItem_toChange, inPointOffset, outPointOffset);
+    success = await addHandlesToTrackItem(project, sequence, trackItem_toChange, inPointOffset, outPointOffset);
   } else {
     log("No trackItem selected.", "red");
     throw new Error("no trackItem is selected at sequence");

--- a/sample-panels/3psample-panel/html/src/sequence.ts
+++ b/sample-panels/3psample-panel/html/src/sequence.ts
@@ -21,7 +21,7 @@ import type {
   VideoClipTrackItem,
 } from "../types.d.ts";
 import { getProjectColumnsMetadata } from "./metadata.js";
-import { getClipProjectItem } from "./projectPanel.js";
+import { getClipProjectItem, setFootageInterpretation } from "./projectPanel.js";
 const ppro = require("premierepro") as premierepro;
 import { log } from "./utils";
 
@@ -200,7 +200,7 @@ export async function addHandlesToTrackItem(
           currentMetadata.ColumnName == "Media Start"
           ){
             projItem_startTime = ppro.TickTime.createWithTicks(currentMetadata.ColumnValue);
-            ppro.TickTime.create
+            
         }else if (
           currentMetadata.ColumnID == "Column.Intrinsic.MediaEnd" &&
           currentMetadata.ColumnName == "Media End"
@@ -242,6 +242,139 @@ export async function addHandlesToTrackItem(
             compoundAction.addAction(action1);
             compoundAction.addAction(action2);
           }, `Add Handles [${inpoint_offset_secs}s, ${outpoint_offset_secs}s]`);
+        
+        success = true;
+        })
+      }else{
+        log("Could not adjust trackItem in/out points due to media limits.", "red");
+      }
+    }catch (err) {
+      log(err.toString(), "red");
+    }
+  }else{
+    log("No track item provided.", "red")
+  }
+
+  return success;
+}
+
+/*
+  * Add media handles to both the start and end of a track item.  Adding a handle
+  * value of 1 frame to the start and end will add 1 frame of media to the start
+  * of the track item, and add 1 frame of media to the end of the track item.
+  * 
+  * To truncate clips, a negative offset value may be used (effectively removing,
+  * rather than adding, media handles).
+  * 
+  * @param project The current working project
+  * @param trackItem_toChange The target track item to modify
+  * @param inpoint_offset_secs The amount of media to add to the start of the track item, in frames
+  * @param outpoint_offset_secs The amount of media to add to the end of the track item, in frames
+  * @returns boolean, where true indicates success, and false indicates faiure
+  */
+export async function addHandlesToTrackItem_usingTicks(
+                                  project: Project, 
+                                  sequence: Sequence,
+                                  trackItem_toChange: VideoClipTrackItem | AudioClipTrackItem, 
+                                  inpoint_offset_frames: number = 0, 
+                                  outpoint_offset_frames: number = 0
+                                ) {
+  let success = false;
+  
+  if(trackItem_toChange){
+  
+    if ( !(Number.isInteger(inpoint_offset_frames)) || !(Number.isInteger(outpoint_offset_frames)) ){
+      throw new Error("Frame offset arguments must be be integers.");
+    }
+
+    try{
+      const ticks_per_sec = 254016000000;
+
+      var projItem = await trackItem_toChange.getProjectItem();
+      var clipProjItem = await ppro.ClipProjectItem.cast(projItem);
+
+      var projItem_metadata = await ppro.Metadata.getProjectColumnsMetadata(projItem);
+      var projItem_metadata_json = JSON.parse(projItem_metadata);
+      var projItem_startTime;
+      var projItem_endTime;
+      
+      var projItem_interpret = await clipProjItem.getFootageInterpretation();
+      
+      var projItem_timebase = await projItem_interpret.getFrameRate();
+      var seq_timebase = ticks_per_sec/Number(await sequence.getTimebase());
+      var projItem_Framerate = ppro.FrameRate.createWithValue(projItem_timebase);
+      var seq_Framerate = ppro.FrameRate.createWithValue(seq_timebase);
+      
+      for (var currentMetadata of projItem_metadata_json){
+        if (projItem_startTime && projItem_endTime){
+          break;
+        }else if (
+          currentMetadata.ColumnID == "Column.Intrinsic.MediaStart" && 
+          currentMetadata.ColumnName == "Media Start"
+          ){
+            projItem_startTime = ppro.TickTime.createWithTicks(currentMetadata.ColumnValue);
+            
+        }else if (
+          currentMetadata.ColumnID == "Column.Intrinsic.MediaEnd" &&
+          currentMetadata.ColumnName == "Media End"
+          ){
+            projItem_endTime = ppro.TickTime.createWithTicks(currentMetadata.ColumnValue);
+        }
+      }
+
+      var trackItem_inPoint = await trackItem_toChange.getInPoint();
+      var trackItem_outPoint = await trackItem_toChange.getOutPoint();
+
+      var trackItem_inPoint_ticks_absolute = Number(trackItem_inPoint.ticks);
+      var trackItem_outPoint_ticks_absolute = Number(trackItem_outPoint.ticks);
+      var trackItem_inPoint_ticks_offset = Number(trackItem_inPoint.ticks) + Number(projItem_startTime.ticks);
+      var trackItem_outPoint_ticks_offset = Number(trackItem_outPoint.ticks) + Number(projItem_startTime.ticks);
+
+      var inpoint_offset_TickTime = ppro.TickTime.createWithFrameAndFrameRate(inpoint_offset_frames, projItem_Framerate);
+      var outpoint_offset_TickTime = ppro.TickTime.createWithFrameAndFrameRate(outpoint_offset_frames, projItem_Framerate);
+      var inpoint_offset_ticks = Number(inpoint_offset_TickTime.ticks);      
+      var outpoint_offset_ticks = Number(outpoint_offset_TickTime.ticks);
+
+      // we need to consider the source and sequence timebases, since we're adding handles at the sequence level,
+      // but modifying the source in/out.
+      //
+      // For Example:  If with a sequence at 30FPS and a source clip at 60FPS, we need to add 60 frames of source
+      // in order to add 30 frames of handle at the sequence level.
+      var source_sequence_timebase_ratio = projItem_Framerate.value/seq_Framerate.value;
+
+      // Compensate for source:sequence timebase ratio
+      // var newInPoint_ticks_absolute = trackItem_inPoint_ticks_absolute - (inpoint_offset_ticks * source_sequence_timebase_ratio);
+      // var newOutPoint_ticks_absolute = trackItem_outPoint_ticks_absolute + (outpoint_offset_ticks * source_sequence_timebase_ratio);
+      // var newInPoint_ticks_offset = trackItem_inPoint_ticks_offset - (inpoint_offset_ticks * source_sequence_timebase_ratio);
+      // var newOutPoint_ticks_offset = trackItem_outPoint_ticks_offset + (outpoint_offset_ticks* source_sequence_timebase_ratio);
+      
+      // Ignore source:sequence timebase ratio, and use source framerate only.
+      var newInPoint_ticks_absolute = trackItem_inPoint_ticks_absolute - inpoint_offset_ticks;
+      var newOutPoint_ticks_absolute = trackItem_outPoint_ticks_absolute + outpoint_offset_ticks;
+      var newInPoint_ticks_offset = trackItem_inPoint_ticks_offset - inpoint_offset_ticks;
+      var newOutPoint_ticks_offset = trackItem_outPoint_ticks_offset + outpoint_offset_ticks;
+
+
+      if (
+        (projItem_startTime != undefined && projItem_endTime != undefined) &&
+        newInPoint_ticks_offset >= projItem_startTime.ticks &&
+        newOutPoint_ticks_offset <= projItem_endTime.ticks &&
+        newInPoint_ticks_offset <= newOutPoint_ticks_offset
+      ){
+        project.lockedAccess(() => {
+          project.executeTransaction((compoundAction) => {
+            
+            var action1 = trackItem_toChange.createSetInPointAction(
+              ppro.TickTime.createWithTicks(String(newInPoint_ticks_absolute))
+            );
+
+            var action2 = trackItem_toChange.createSetOutPointAction(
+              ppro.TickTime.createWithTicks(String(newOutPoint_ticks_absolute))
+            );
+
+            compoundAction.addAction(action1);
+            compoundAction.addAction(action2);
+          }, `Add Handles [${inpoint_offset_frames}f, ${outpoint_offset_frames}f]`);
         
         success = true;
         })

--- a/sample-panels/3psample-panel/html/src/sequence.ts
+++ b/sample-panels/3psample-panel/html/src/sequence.ts
@@ -163,104 +163,6 @@ export async function trimSelectedItem(project: Project, sequence: Sequence) {
 
 /*
   * Add media handles to both the start and end of a track item.  Adding a handle
-  * value of 1 second to the start and end will add 1 second of media to the start
-  * of the track item, and add 1 second of media to the end of the track item.
-  * 
-  * To truncate clips, a negative offset value may be used (effectively removing,
-  * rather than adding, media handles).
-  * 
-  * @param project The current working project
-  * @param trackItem_toChange The target track item to modify
-  * @param inpoint_offset_secs The amount of media to add to the start of the track item, in seconds
-  * @param outpoint_offset_secs The amount of media to add to the end of the track item, in seconds
-  * @returns boolean, where true indicates success, and false indicates faiure
-  */
-export async function addHandlesToTrackItem(
-                                  project: Project, 
-                                  trackItem_toChange: VideoClipTrackItem | AudioClipTrackItem, 
-                                  inpoint_offset_secs: number = 0.0, 
-                                  outpoint_offset_secs: number = 0.0
-                                ) {
-  let success = false;
-  
-  if(trackItem_toChange){
-  
-    try{
-
-      var projItem = await trackItem_toChange.getProjectItem();
-      var projItem_metadata = await ppro.Metadata.getProjectColumnsMetadata(projItem);
-      var projItem_metadata_json = JSON.parse(projItem_metadata);
-      var projItem_startTime;
-      var projItem_endTime;
-      
-      for (var currentMetadata of projItem_metadata_json){
-        if (projItem_startTime && projItem_endTime){
-          break;
-        }else if (
-          currentMetadata.ColumnID == "Column.Intrinsic.MediaStart" && 
-          currentMetadata.ColumnName == "Media Start"
-          ){
-            projItem_startTime = ppro.TickTime.createWithTicks(currentMetadata.ColumnValue);
-            
-        }else if (
-          currentMetadata.ColumnID == "Column.Intrinsic.MediaEnd" &&
-          currentMetadata.ColumnName == "Media End"
-          ){
-            projItem_endTime = ppro.TickTime.createWithTicks(currentMetadata.ColumnValue);
-        }
-      }
-
-      var trackItem_inPoint = await trackItem_toChange.getInPoint();
-      var trackItem_outPoint = await trackItem_toChange.getOutPoint();
-
-      var trackItem_inPoint_secs_absolute = trackItem_inPoint.seconds;
-      var trackItem_outPoint_secs_absolute = trackItem_outPoint.seconds;
-      var trackItem_inPoint_secs_offset = trackItem_inPoint.seconds + projItem_startTime.seconds;
-      var trackItem_outPoint_secs_offset = trackItem_outPoint.seconds + projItem_startTime.seconds;
-
-      var newInPoint_secs_absolute = trackItem_inPoint_secs_absolute - inpoint_offset_secs;
-      var newOutPoint_secs_absolute = trackItem_outPoint_secs_absolute + outpoint_offset_secs;
-      var newInPoint_secs_offset = trackItem_inPoint_secs_offset - inpoint_offset_secs;
-      var newOutPoint_secs_offset = trackItem_outPoint_secs_offset + outpoint_offset_secs;
-
-      if (
-        (projItem_startTime != undefined && projItem_endTime != undefined) &&
-        newInPoint_secs_offset >= projItem_startTime.seconds &&
-        newOutPoint_secs_offset <= projItem_endTime.seconds &&
-        newInPoint_secs_offset <= newOutPoint_secs_offset
-      ){
-        project.lockedAccess(() => {
-          project.executeTransaction((compoundAction) => {
-            
-            var action1 = trackItem_toChange.createSetInPointAction(
-              ppro.TickTime.createWithSeconds(newInPoint_secs_absolute)
-            );
-
-            var action2 = trackItem_toChange.createSetOutPointAction(
-              ppro.TickTime.createWithSeconds(newOutPoint_secs_absolute)
-            );
-
-            compoundAction.addAction(action1);
-            compoundAction.addAction(action2);
-          }, `Add Handles [${inpoint_offset_secs}s, ${outpoint_offset_secs}s]`);
-        
-        success = true;
-        })
-      }else{
-        log("Could not adjust trackItem in/out points due to media limits.", "red");
-      }
-    }catch (err) {
-      log(err.toString(), "red");
-    }
-  }else{
-    log("No track item provided.", "red")
-  }
-
-  return success;
-}
-
-/*
-  * Add media handles to both the start and end of a track item.  Adding a handle
   * value of 1 frame to the start and end will add 1 frame of media to the start
   * of the track item, and add 1 frame of media to the end of the track item.
   * 
@@ -273,7 +175,7 @@ export async function addHandlesToTrackItem(
   * @param outpoint_offset_secs The number of frames to add to the end of the track item in the sequence
   * @returns boolean, where true indicates success, and false indicates faiure
   */
-export async function addHandlesToTrackItem_usingTicks(
+export async function addHandlesToTrackItem(
                                   project: Project, 
                                   sequence: Sequence,
                                   trackItem_toChange: VideoClipTrackItem | AudioClipTrackItem, 


### PR DESCRIPTION
Added a sample function `addHandlesToTrackItem()` to the **sequence.ts** sample.
## Description

The new sample function `addHandlesToTrackItem()` provides a sample real-word use case for the Premiere Pro UXP API,  showcasing the combination of a number of methods and the use of Ticks for mathematical operations.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
