### PR TITLE
added user selection and multicam support for marker and metadata export

### DIFF
--- a/sample-panels/metadata-handler/index.html
+++ b/sample-panels/metadata-handler/index.html
@@ -205,6 +205,8 @@
       </div>
       <div class="section">
         <h4>Metadata Exporter</h4>
+        <h6>All project items will be exported if no project items are selected.</h6>
+        <br>
         <sp-radio-group id="time-type">
           <sp-label slot="label">Select Time Type:</sp-label>
           <sp-radio value="smpte" checked>SMPTE Timecode</sp-radio>
@@ -223,6 +225,11 @@
 
       <div class="section">
         <h4>Clip Marker Exporter</h4>
+        <h6>All project items will be exported if no project items are selected.</h6>
+        <h6>Items that contain no markers are skipped and not exported.</h6>
+        <h6>Sequences are ignored during this export.  Markers are exported only for media items.</h6>
+         <h6>Multicams are included in the export.</h6>
+        <br>
         <div>
           <sp-radio-group id="clip-marker-type">
             <sp-label slot="label">Select File Type:</sp-label>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Users can now export clips markers and metadata using a project item selection, rather than always being forced to export the entire project contents.  If the user has not made a project item selection, the entire contents of the project will still be exported.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
