### PR TITLE
Fix "Unknown menu item" log message for submenu items

### DIFF
--- a/sample-panels/premiere-api/html/index.ts
+++ b/sample-panels/premiere-api/html/index.ts
@@ -317,13 +317,14 @@ entrypoints.setup({
             },
           ],
         },
-        { id: "separator", "label": "-" },
+        { id: "separator", label: "-" },
         {
           id: "reload",
           label: "Reload Panel",
           enabled: true,
           checked: false,
         },
+        // Shorthand for a separator menu item.
         "-",
         {
           id: "toggle-checked",

--- a/sample-panels/premiere-api/html/index.ts
+++ b/sample-panels/premiere-api/html/index.ts
@@ -349,6 +349,14 @@ entrypoints.setup({
             this.menuItems.getItem(id).checked = !this.menuItems.getItem(id).checked;
             break;
 
+          case "submenu-item1":
+            log("Submenu item 1 clicked");
+            break;
+
+          case "submenu-item2":
+            log("Submenu item 2 clicked");
+            break;
+
           default:
             log(`Unknown menu item invoked: ${id}`, "red");
             break;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The sample submenu items were not properly included in the "invokeMenu" handler function, resulting in printing red log messages for "Unknown menu item invoked". This adds both submenu items to the switch-case statement to cover those cases; even though Submenu Item 2 is declared disabled we handle it anyways since its possible to programmatically enable menu items and don't want to reintroduce this problem.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Fixing a "bug" to make sure we handle all possible cases in our menu example.

Additionally doing some cleanup and leaving a comment around the menu separators, mostly to note that using the string `"-"` is a shorthand for adding a menu separator.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually checked all _enabled_ custom menu items print the correct log message or perform their intended behavior.

## Screenshots (if appropriate):

<img width="611" height="592" alt="image" src="https://github.com/user-attachments/assets/60d9e671-1d82-4f35-9701-e06a505effe5" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
