### PR TITLE
Add ProjectConverter.exportAAF

### DIFF
--- a/sample-panels/premiere-api/html/index.html
+++ b/sample-panels/premiere-api/html/index.html
@@ -145,6 +145,10 @@
         />
       </div>
       <div class="section">
+        <h4>Project Converter</h4>
+        <sp-button id="export-aaf">Export as AAF</sp-button>
+      </div>
+      <div class="section">
         <h4>VideoTrack</h4>
         <sp-button id="set-video-track-name">Set Video Track Name</sp-button>
       </div>

--- a/sample-panels/premiere-api/html/index.ts
+++ b/sample-panels/premiere-api/html/index.ts
@@ -201,6 +201,7 @@ import {
 } from "./src/encoderManager";
 import { exportTranscript, importTranscript } from "./src/transcript";
 import {
+  exportAAF,
   exportAsFinalCutProXML,
   exportAsOpenTimelineIO,
 } from "./src/projectConverter";
@@ -475,6 +476,36 @@ async function createSequenceWithPresetPathClicked() {
     }
   } catch (error) {
     log(`Error creating sequence with preset path: ${error}`, "red");
+  }
+}
+
+async function exportAAFClicked() {
+  const project = await getProject();
+  if (!project) {
+    log(`Failed to get project`, "red");
+    return;
+  }
+
+  const sequence = await project.getActiveSequence();
+  if (!sequence) {
+    log(`Failed to get active sequence`, "red");
+    return;
+  }
+
+  log("Please select output directory for the AAF export");
+  // @ts-expect-error - uxp.storage.localFileSystem is not typed correctly
+  const outputFolder = await uxp.storage.localFileSystem.getFolder();
+  if (!outputFolder?.nativePath) {
+    log("Selection of output folder failed. Please try again", "red");
+    return;
+  }
+
+  const outputFilePath = `${outputFolder.nativePath}/${sequence.name}.aaf`;
+  const success = await exportAAF(sequence, outputFilePath);
+  if (success) {
+    log(`Successfully exported AAF to ${outputFilePath}`);
+  } else {
+    log(`Failed to export AAF`, "red");
   }
 }
 
@@ -2460,6 +2491,7 @@ window.addEventListener("load", async () => {
   registerClick("set-caption-track-name", setCaptionTrackNameClicked);
   registerClick("show-guid-for-all-markers", showGuidForAllMarkersClicked);
   registerClick("create-sequence-with-preset-path", createSequenceWithPresetPathClicked);
+  registerClick("export-aaf", exportAAFClicked);
   registerClick("set-video-track-name", setVideoTrackNameClicked);
 
   //project events registering

--- a/sample-panels/premiere-api/html/src/projectConverter.ts
+++ b/sample-panels/premiere-api/html/src/projectConverter.ts
@@ -19,7 +19,7 @@ const ppro = require("premierepro") as premierepro;
 
 export async function exportAAF(sequence: Sequence, outputFilePath: string) {
   try {
-    return await ppro.ProjectConverter.exportAAF(sequence, outputFilePath);
+    return await ppro.ProjectConverter.exportAAF(sequence, outputFilePath, new ppro.AAFExportOptions());
   } catch (e) {
     log(`Error exporting as AAF: ${e}`, "red");
     return false;

--- a/sample-panels/premiere-api/html/src/projectConverter.ts
+++ b/sample-panels/premiere-api/html/src/projectConverter.ts
@@ -17,6 +17,15 @@ import { log } from "./utils";
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const ppro = require("premierepro") as premierepro;
 
+export async function exportAAF(sequence: Sequence, outputFilePath: string) {
+  try {
+    return await ppro.ProjectConverter.exportAAF(sequence, outputFilePath);
+  } catch (e) {
+    log(`Error exporting as AAF: ${e}`, "red");
+    return false;
+  }
+}
+
 /**
  * Export a sequence as Final Cut Pro XML to a user-selected output directory.
  */

--- a/sample-panels/premiere-api/html/types.d.ts
+++ b/sample-panels/premiere-api/html/types.d.ts
@@ -1,4 +1,5 @@
 export declare type premierepro = {
+  AAFExportOptions: AAFExportOptions
   AppPreference: AppPreferenceStatic
   AudioClipTrackItem: AudioClipTrackItemStatic
   AudioComponentChain: AudioComponentChainStatic
@@ -56,6 +57,7 @@ export declare type AAFExportOptions = {
    * Constructs a new instance of the AAFExportOptions class.
    * @constructor
    */
+  new (): AAFExportOptions
   (): AAFExportOptions
 
   /**

--- a/sample-panels/premiere-api/html/types.d.ts
+++ b/sample-panels/premiere-api/html/types.d.ts
@@ -51,6 +51,194 @@ export declare type premierepro = {
   Constants: typeof Constants
 }
 
+export declare type AAFExportOptions = {
+  /**
+   * Constructs a new instance of the AAFExportOptions class.
+   * @constructor
+   */
+  (): AAFExportOptions
+
+  /**
+   * When true, renders the sequence video to a single media file for AAF export (video mixdown) instead of relying only on linked source clips
+   *
+   * @param mixdownVideo
+   * @version 26.3.0
+   */
+  setMixdownVideo(mixdownVideo: boolean): AAFExportOptions
+
+  /**
+   * When true, exports multichannel audio as separate mono media files (one file per channel)
+   *
+   * @param explodeToMono
+   * @version 26.3.0
+   */
+  setExplodeToMono(explodeToMono: boolean): AAFExportOptions
+
+  /**
+   * Set the audio sample rate
+   *
+   * @param sampleRate
+   * @version 26.3.0
+   */
+  setSampleRate(sampleRate: number): AAFExportOptions
+
+  /**
+   * Set the audio bits per sample
+   *
+   * @param bitsPerSample
+   * @version 26.3.0
+   */
+  setBitsPerSample(bitsPerSample: number): AAFExportOptions
+
+  /**
+   * Set whether to embed audio in the AAF file
+   *
+   * @param embedAudio
+   * @version 26.3.0
+   */
+  setEmbedAudio(embedAudio: boolean): AAFExportOptions
+
+  /**
+   * Set the audio file format (0 for AIFF, 1 for WAV)
+   *
+   * @param audioFileFormat
+   * @version 26.3.0
+   */
+  setAudioFileFormat(audioFileFormat: number): AAFExportOptions
+
+  /**
+   * Set whether to trim sources
+   *
+   * @param trimSources
+   * @version 26.3.0
+   */
+  setTrimSources(trimSources: boolean): AAFExportOptions
+
+  /**
+   * Set the number of handle frames
+   *
+   * @param handleFrames
+   * @version 26.3.0
+   */
+  setHandleFrames(handleFrames: number): AAFExportOptions
+
+  /**
+   * Path to the encoder preset file (.epr) used when mixdown video is enabled
+   *
+   * @param videoMixdownPresetPath
+   * @version 26.3.0
+   */
+  setVideoMixdownPresetPath(videoMixdownPresetPath: string): AAFExportOptions
+
+  /**
+   * Set whether to render audio effects
+   *
+   * @param renderAudioEffects
+   * @version 26.3.0
+   */
+  setRenderAudioEffects(renderAudioEffects: boolean): AAFExportOptions
+
+  /**
+   * Set whether to interleave without effects
+   *
+   * @param interleaveWithoutEffects
+   * @version 26.3.0
+   */
+  setInterleaveWithoutEffects(interleaveWithoutEffects: boolean): AAFExportOptions
+
+  /**
+   * When true, exploded mono audio is written under a subdirectory named after the folder that contained each clip's source media on disk
+   *
+   * @param preserveParentFolder
+   * @version 26.3.0
+   */
+  setPreserveParentFolder(preserveParentFolder: boolean): AAFExportOptions
+
+  /**
+   * True if the exporter will render a single mixed-down video file
+   * @readonly
+   * @version 26.3.0
+   */
+  readonly mixdownVideo: boolean
+
+  /**
+   * True if multichannel audio is exported as separate mono files per channel
+   * @readonly
+   * @version 26.3.0
+   */
+  readonly explodeToMono: boolean
+
+  /**
+   * Get the audio sample rate
+   * @readonly
+   * @version 26.3.0
+   */
+  readonly sampleRate: number
+
+  /**
+   * Get the audio bits per sample
+   * @readonly
+   * @version 26.3.0
+   */
+  readonly bitsPerSample: number
+
+  /**
+   * Get whether to embed audio in the AAF file
+   * @readonly
+   * @version 26.3.0
+   */
+  readonly embedAudio: boolean
+
+  /**
+   * Get the audio file format (0 for AIFF, 1 for WAV)
+   * @readonly
+   * @version 26.3.0
+   */
+  readonly audioFileFormat: number
+
+  /**
+   * Get whether to trim sources
+   * @readonly
+   * @version 26.3.0
+   */
+  readonly trimSources: boolean
+
+  /**
+   * Get the number of handle frames
+   * @readonly
+   * @version 26.3.0
+   */
+  readonly handleFrames: number
+
+  /**
+   * Get the video mixdown preset path
+   * @readonly
+   * @version 26.3.0
+   */
+  readonly videoMixdownPresetPath: string
+
+  /**
+   * Get whether to render audio effects
+   * @readonly
+   * @version 26.3.0
+   */
+  readonly renderAudioEffects: boolean
+
+  /**
+   * Get whether to interleave without effects
+   * @readonly
+   * @version 26.3.0
+   */
+  readonly interleaveWithoutEffects: boolean
+
+  /**
+   * Get whether to preserve parent folder
+   * @readonly
+   * @version 26.3.0
+   */
+  readonly preserveParentFolder: boolean
+}
+
 export declare type Action = {
 }
 
@@ -2311,6 +2499,16 @@ export declare type ProjectColorSettings = {
 }
 
 export declare type ProjectConverterStatic = {
+
+  /**
+   * Export a sequence as an AAF (Advanced Authoring Format) file to the specified output path.
+   *
+   * @param sequence
+   * @param filePath
+   * @param aafExportOptions
+   * @version 26.3.0
+   */
+  exportAAF(sequence: Sequence, filePath: string, aafExportOptions?: AAFExportOptions): Promise<boolean>
 
   /**
    * Export a sequence as Final Cut Pro XML to the specified output file path.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Add an example using the 26.3 Beta API ProjectConverter.exportAAF(sequence, outputFilePath, aafExportOptions).

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Adding an example to show how this API can be used for development purposes.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified that
* Projects can be successfully exported in AAF format
* These projects can also be reimported

## Screenshots (if appropriate):

<img width="818" height="546" alt="image" src="https://github.com/user-attachments/assets/3fbaa76c-68ea-491f-a7e4-ae685cdedb38" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
