### PR TITLE
Add Transcript.querySupportedLanguages

### DIFF
--- a/sample-panels/premiere-api/html/index.html
+++ b/sample-panels/premiere-api/html/index.html
@@ -145,6 +145,10 @@
         />
       </div>
       <div class="section">
+        <h4>Transcript</h4>
+        <sp-button id="query-supported-languages">Query Supported Languages</sp-button>
+      </div>
+      <div class="section">
         <h4>VideoTrack</h4>
         <sp-button id="set-video-track-name">Set Video Track Name</sp-button>
       </div>

--- a/sample-panels/premiere-api/html/index.ts
+++ b/sample-panels/premiere-api/html/index.ts
@@ -478,6 +478,23 @@ async function createSequenceWithPresetPathClicked() {
   }
 }
 
+async function querySupportedLanguagesClicked() {
+  const languages = ppro.Transcript.querySupportedLanguages();
+  if (languages.length === 0) {
+    log("No supported languages found.", "red");
+    return;
+  }
+
+  for (const language of languages) {
+    let logLine = `Language: ${language.displayString}, code: ${language.languageCode}`;
+    if (language.locale) {
+      logLine += `, locale: ${language.locale}`;
+    }
+
+    log(logLine);
+  }
+}
+
 async function showGuidForAllMarkersClicked() {
   const project = await getProject();
   if (!project) {
@@ -2460,6 +2477,7 @@ window.addEventListener("load", async () => {
   registerClick("set-caption-track-name", setCaptionTrackNameClicked);
   registerClick("show-guid-for-all-markers", showGuidForAllMarkersClicked);
   registerClick("create-sequence-with-preset-path", createSequenceWithPresetPathClicked);
+  registerClick("query-supported-languages", querySupportedLanguagesClicked);
   registerClick("set-video-track-name", setVideoTrackNameClicked);
 
   //project events registering

--- a/sample-panels/premiere-api/html/types.d.ts
+++ b/sample-panels/premiere-api/html/types.d.ts
@@ -4076,6 +4076,11 @@ export declare type TranscriptStatic = {
   createImportTextSegmentsAction(textSegments: TextSegments, clipProjectItem: ClipProjectItem): Action
 
   /**
+   * Returns the list of language services available for transcription
+   */
+  querySupportedLanguages(): Array<{displayString: string, languageCode: string, locale: string}>
+
+  /**
    * Export transcripts inside of clipProjectItem as JSON string if transcript exist
    *
    * @param clipProjectItem

--- a/sample-panels/premiere-api/html/types.d.ts
+++ b/sample-panels/premiere-api/html/types.d.ts
@@ -4077,6 +4077,7 @@ export declare type TranscriptStatic = {
 
   /**
    * Returns the list of language services available for transcription
+   * @version 26.3.0
    */
   querySupportedLanguages(): Array<{displayString: string, languageCode: string, locale: string}>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Add an example using the 26.3 Beta API `Transcript.querySupportedLanguages()`.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified as of Beta build 26.3.0.47 this API is available and prints supported languages.

## Screenshots (if appropriate):

<img width="480" height="592" alt="image" src="https://github.com/user-attachments/assets/f229d79a-a9d5-40a9-852d-01eb2c4c618d" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
