### PR TITLE
feat: verified setEmbeddedXMPEnabled(), launchEncoder(), setSidecarXMPEnabled() and startBatch() apis

### DIFF
--- a/sample-panels/premiere-api/html/index.html
+++ b/sample-panels/premiere-api/html/index.html
@@ -133,7 +133,8 @@
       </div>
       <div class="section">
         <h4>EncoderManager</h4>
-        <sp-button id="set-embedded-xmp-enabled">Set Embedded XMP Enabled</sp-button>
+        <sp-button id="toggle-embedded-xmp">Toggle Embedded XMP</sp-button>
+        <sp-button id="toggle-sidecar-xmp">Toggle Sidecar XMP</sp-button>
         <sp-button id="launch-encoder">Launch Encoder</sp-button>
         <sp-button id="start-batch-encode">Start Batch Encode</sp-button>
       </div>

--- a/sample-panels/premiere-api/html/index.html
+++ b/sample-panels/premiere-api/html/index.html
@@ -134,6 +134,8 @@
       <div class="section">
         <h4>EncoderManager</h4>
         <sp-button id="set-embedded-xmp-enabled">Set Embedded XMP Enabled</sp-button>
+        <sp-button id="launch-encoder">Launch Encoder</sp-button>
+        <sp-button id="start-batch-encode">Start Batch Encode</sp-button>
       </div>
       <div class="section">
         <h4>Marker</h4>

--- a/sample-panels/premiere-api/html/index.html
+++ b/sample-panels/premiere-api/html/index.html
@@ -132,6 +132,10 @@
         <sp-button id="set-caption-track-name">Set Caption Track Name</sp-button>
       </div>
       <div class="section">
+        <h4>EncoderManager</h4>
+        <sp-button id="set-embedded-xmp-enabled">Set Embedded XMP Enabled</sp-button>
+      </div>
+      <div class="section">
         <h4>Marker</h4>
         <sp-button id="show-guid-for-all-markers">Show Guid for All Markers</sp-button>
       </div>

--- a/sample-panels/premiere-api/html/index.html
+++ b/sample-panels/premiere-api/html/index.html
@@ -132,7 +132,7 @@
         <sp-button id="set-caption-track-name">Set Caption Track Name</sp-button>
       </div>
       <div class="section">
-        <h4>EncoderManager</h4>
+        <h4>EncoderManager(Requires AME)</h4>
         <sp-button id="toggle-embedded-xmp">Toggle Embedded XMP</sp-button>
         <sp-button id="toggle-sidecar-xmp">Toggle Sidecar XMP</sp-button>
         <sp-button id="launch-encoder">Launch Encoder</sp-button>

--- a/sample-panels/premiere-api/html/index.ts
+++ b/sample-panels/premiere-api/html/index.ts
@@ -198,6 +198,7 @@ import type {
 import {
   encodeFile,
   encodeFirstSelectedProjectItem,
+  setEmbeddedXMPEnabled,
 } from "./src/encoderManager";
 import { exportTranscript, hasTranscript, importTranscript } from "./src/transcript";
 import {
@@ -2418,6 +2419,15 @@ async function encodeFirstSelectedProjectItemClicked() {
   );
 }
 
+async function setEmbeddedXMPEnabledClicked() {
+  const result = await setEmbeddedXMPEnabled(true);
+  log(
+    result
+      ? "setEmbeddedXMPEnabled(true) succeeded"
+      : "setEmbeddedXMPEnabled(true) failed"
+  );
+}
+
 // Transcript button events
 async function importTranscriptClicked() {
   const project = await getProject();
@@ -2724,6 +2734,7 @@ window.addEventListener("load", async () => {
     "encode-first-selected-project-item",
     encodeFirstSelectedProjectItemClicked
   );
+  registerClick("set-embedded-xmp-enabled", setEmbeddedXMPEnabledClicked);
 
   // Import controls
   registerClick("import-ae-component", importAeComponentClicked);

--- a/sample-panels/premiere-api/html/index.ts
+++ b/sample-panels/premiere-api/html/index.ts
@@ -199,6 +199,8 @@ import {
   encodeFile,
   encodeFirstSelectedProjectItem,
   setEmbeddedXMPEnabled,
+  launchEncoder,
+  startBatchEncode,
 } from "./src/encoderManager";
 import { exportTranscript, hasTranscript, importTranscript } from "./src/transcript";
 import {
@@ -2428,6 +2430,24 @@ async function setEmbeddedXMPEnabledClicked() {
   );
 }
 
+async function launchEncoderClicked() {
+  const result = await launchEncoder();
+  log(
+    result
+      ? "launchEncoder() succeeded"
+      : "launchEncoder() failed"
+  );
+}
+
+async function startBatchEncodeClicked() {
+  const result = await startBatchEncode();
+  log(
+    result
+      ? "startBatchEncode() succeeded"
+      : "startBatchEncode() failed"
+  );
+}
+
 // Transcript button events
 async function importTranscriptClicked() {
   const project = await getProject();
@@ -2735,6 +2755,8 @@ window.addEventListener("load", async () => {
     encodeFirstSelectedProjectItemClicked
   );
   registerClick("set-embedded-xmp-enabled", setEmbeddedXMPEnabledClicked);
+  registerClick("launch-encoder", launchEncoderClicked);
+  registerClick("start-batch-encode", startBatchEncodeClicked);
 
   // Import controls
   registerClick("import-ae-component", importAeComponentClicked);

--- a/sample-panels/premiere-api/html/index.ts
+++ b/sample-panels/premiere-api/html/index.ts
@@ -198,7 +198,8 @@ import type {
 import {
   encodeFile,
   encodeFirstSelectedProjectItem,
-  setEmbeddedXMPEnabled,
+  toggleEmbeddedXMP,
+  toggleSidecarXMP,
   launchEncoder,
   startBatchEncode,
 } from "./src/encoderManager";
@@ -2421,13 +2422,12 @@ async function encodeFirstSelectedProjectItemClicked() {
   );
 }
 
-async function setEmbeddedXMPEnabledClicked() {
-  const result = await setEmbeddedXMPEnabled(true);
-  log(
-    result
-      ? "setEmbeddedXMPEnabled(true) succeeded"
-      : "setEmbeddedXMPEnabled(true) failed"
-  );
+async function toggleEmbeddedXMPClicked() {
+  await toggleEmbeddedXMP();
+}
+
+async function toggleSidecarXMPClicked() {
+  await toggleSidecarXMP();
 }
 
 async function launchEncoderClicked() {
@@ -2754,7 +2754,8 @@ window.addEventListener("load", async () => {
     "encode-first-selected-project-item",
     encodeFirstSelectedProjectItemClicked
   );
-  registerClick("set-embedded-xmp-enabled", setEmbeddedXMPEnabledClicked);
+  registerClick("toggle-embedded-xmp", toggleEmbeddedXMPClicked);
+  registerClick("toggle-sidecar-xmp", toggleSidecarXMPClicked);
   registerClick("launch-encoder", launchEncoderClicked);
   registerClick("start-batch-encode", startBatchEncodeClicked);
 

--- a/sample-panels/premiere-api/html/index.ts
+++ b/sample-panels/premiere-api/html/index.ts
@@ -2423,11 +2423,13 @@ async function encodeFirstSelectedProjectItemClicked() {
 }
 
 async function toggleEmbeddedXMPClicked() {
-  await toggleEmbeddedXMP();
+  const { success, state } = await toggleEmbeddedXMP();
+  log(success ? `setEmbeddedXMPEnabled(${state}) succeeded` : `setEmbeddedXMPEnabled(${state}) failed`);
 }
 
 async function toggleSidecarXMPClicked() {
-  await toggleSidecarXMP();
+  const { success, state } = await toggleSidecarXMP();
+  log(success ? `setSidecarXMPEnabled(${state}) succeeded` : `setSidecarXMPEnabled(${state}) failed`);
 }
 
 async function launchEncoderClicked() {

--- a/sample-panels/premiere-api/html/package-lock.json
+++ b/sample-panels/premiere-api/html/package-lock.json
@@ -6,8 +6,8 @@
     "": {
       "devDependencies": {
         "@adobe/cc-ext-uxp-types": "^7.3.1",
-        "@adobe/eslint-plugin-premierepro": "^26.3.0-beta.59",
-        "@adobe/premierepro": "^26.3.0-beta.59",
+        "@adobe/eslint-plugin-premierepro": "^26.3.0-beta.65",
+        "@adobe/premierepro": "^26.3.0-beta.65",
         "@eslint/js": "^9.39.4",
         "@types/node": "^22.10.2",
         "cp-cli": "^2.0.0",
@@ -25,15 +25,16 @@
       "dev": true
     },
     "node_modules/@adobe/eslint-plugin-premierepro": {
-      "version": "26.3.0-beta.59",
-      "resolved": "https://registry.npmjs.org/@adobe/eslint-plugin-premierepro/-/eslint-plugin-premierepro-26.3.0-beta.59.tgz",
-      "integrity": "sha512-xp4G+mIlr6LBk4MwPb+wphvdzgmwvP/oHv+Qlq3JfRmZPMv0Lb61HwJTxT6dJnJ+qNqn8ZOqcgRm/UmlCOe18Q==",
+      "version": "26.3.0-beta.65",
+      "resolved": "https://registry.npmjs.org/@adobe/eslint-plugin-premierepro/-/eslint-plugin-premierepro-26.3.0-beta.65.tgz",
+      "integrity": "sha512-uUADUk+GSz+1EobnYPA60rjX6BWgRT6YZ3OBwIEjfDwK+RV159WvOYpi/BMNg7ja9+1f0yKptvqwaGnVPpWnqg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@typescript-eslint/utils": "^8.58.1"
       },
       "peerDependencies": {
-        "@adobe/premierepro": "26.3.0-beta.59",
+        "@adobe/premierepro": "26.3.0-beta.65",
         "@typescript-eslint/parser": "^8.0.0",
         "eslint": "^9.0.0",
         "typescript": ">=5.0.0"
@@ -48,9 +49,9 @@
       }
     },
     "node_modules/@adobe/premierepro": {
-      "version": "26.3.0-beta.59",
-      "resolved": "https://registry.npmjs.org/@adobe/premierepro/-/premierepro-26.3.0-beta.59.tgz",
-      "integrity": "sha512-oklIYedoVtQ4KnTyTsGVQARu9ZUfomH7447ISMqHhIfNDRJ+HnOUX41Nev5At541N1HxhTq0bJjKs18HjUxO9w==",
+      "version": "26.3.0-beta.65",
+      "resolved": "https://registry.npmjs.org/@adobe/premierepro/-/premierepro-26.3.0-beta.65.tgz",
+      "integrity": "sha512-Rw/YRzzROdVn07nROQhmSdhQjvHgbf7X9THsgHsDMKF1ztGNRKHSz46NWPOyefE8f/MhvRILGNRamql3zyLQtg==",
       "dev": true,
       "engines": {
         "node": ">=24.13.0"

--- a/sample-panels/premiere-api/html/package.json
+++ b/sample-panels/premiere-api/html/package.json
@@ -10,8 +10,8 @@
   },
   "devDependencies": {
     "@adobe/cc-ext-uxp-types": "^7.3.1",
-    "@adobe/eslint-plugin-premierepro": "^26.3.0-beta.59",
-    "@adobe/premierepro": "^26.3.0-beta.59",
+    "@adobe/eslint-plugin-premierepro": "^26.3.0-beta.65",
+    "@adobe/premierepro": "^26.3.0-beta.65",
     "@eslint/js": "^9.39.4",
     "@types/node": "^22.10.2",
     "cp-cli": "^2.0.0",

--- a/sample-panels/premiere-api/html/src/encoderManager.ts
+++ b/sample-panels/premiere-api/html/src/encoderManager.ts
@@ -12,7 +12,11 @@
  * written permission of Adobe.
  **************************************************************************/
 
-import type { premierepro, Project, ProjectItem } from "@adobe/premierepro";
+import type { EncoderManager, premierepro, Project, ProjectItem } from "@adobe/premierepro";
+
+type EncoderManagerExtended = EncoderManager & {
+  setEmbeddedXMPEnabled(enabled: boolean): Promise<boolean>;
+};
 import { getSelectedProjectItems } from "./projectPanel.js";
 import { log } from "./utils";
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -79,6 +83,18 @@ export async function encodeFirstSelectedProjectItem(
       presetPath,
       0 // 0 = entire, 1 = in/out, 2 = work area (only valid for sequence clipProjectItem input)
     );
+  } catch (e) {
+    log(`Error: ${e}`, "red");
+    return false;
+  }
+}
+
+
+export async function setEmbeddedXMPEnabled(enabled: boolean): Promise<boolean> {
+  try {
+    const encoderManager = ppro.EncoderManager.getManager() as EncoderManagerExtended;
+    const result = await encoderManager.setEmbeddedXMPEnabled(enabled);
+    return result;
   } catch (e) {
     log(`Error: ${e}`, "red");
     return false;

--- a/sample-panels/premiere-api/html/src/encoderManager.ts
+++ b/sample-panels/premiere-api/html/src/encoderManager.ts
@@ -14,11 +14,6 @@
 
 import type { EncoderManager, premierepro, Project, ProjectItem } from "@adobe/premierepro";
 
-type EncoderManagerExtended = EncoderManager & {
-  setEmbeddedXMPEnabled(enabled: boolean): Promise<boolean>;
-  launchEncoder(): Promise<boolean>;
-  startBatchEncode(): Promise<boolean>;
-};
 import { getSelectedProjectItems } from "./projectPanel.js";
 import { log } from "./utils";
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -92,10 +87,28 @@ export async function encodeFirstSelectedProjectItem(
 }
 
 
-export async function setEmbeddedXMPEnabled(enabled: boolean): Promise<boolean> {
+let embeddedXMPState = false;
+export async function toggleEmbeddedXMP(): Promise<boolean> {
   try {
-    const encoderManager = ppro.EncoderManager.getManager() as EncoderManagerExtended;
-    return await encoderManager.setEmbeddedXMPEnabled(enabled);
+    embeddedXMPState = !embeddedXMPState;
+    const encoderManager = ppro.EncoderManager.getManager();
+    const result = await encoderManager.setEmbeddedXMPEnabled(embeddedXMPState);
+    log(result ? `setEmbeddedXMPEnabled(${embeddedXMPState}) succeeded` : `setEmbeddedXMPEnabled(${embeddedXMPState}) failed`);
+    return result;
+  } catch (e) {
+    log(`Error: ${e}`, "red");
+    return false;
+  }
+}
+
+let sidecarXMPState = false;
+export async function toggleSidecarXMP(): Promise<boolean> {
+  try {
+    sidecarXMPState = !sidecarXMPState;
+    const encoderManager = ppro.EncoderManager.getManager();
+    const result = await encoderManager.setSidecarXMPEnabled(sidecarXMPState);
+    log(result ? `setSidecarXMPEnabled(${sidecarXMPState}) succeeded` : `setSidecarXMPEnabled(${sidecarXMPState}) failed`);
+    return result;
   } catch (e) {
     log(`Error: ${e}`, "red");
     return false;
@@ -104,7 +117,7 @@ export async function setEmbeddedXMPEnabled(enabled: boolean): Promise<boolean> 
 
 export async function launchEncoder(): Promise<boolean> {
   try {
-    const encoderManager = ppro.EncoderManager.getManager() as EncoderManagerExtended;
+    const encoderManager = ppro.EncoderManager.getManager();
     return await encoderManager.launchEncoder();
   } catch (e) {
     log(`Error: ${e}`, "red");
@@ -114,7 +127,7 @@ export async function launchEncoder(): Promise<boolean> {
 
 export async function startBatchEncode(): Promise<boolean> {
   try {
-    const encoderManager = ppro.EncoderManager.getManager() as EncoderManagerExtended;
+    const encoderManager = ppro.EncoderManager.getManager();
     return await encoderManager.startBatchEncode();
   } catch (e) {
     log(`Error: ${e}`, "red");

--- a/sample-panels/premiere-api/html/src/encoderManager.ts
+++ b/sample-panels/premiere-api/html/src/encoderManager.ts
@@ -93,8 +93,7 @@ export async function encodeFirstSelectedProjectItem(
 export async function setEmbeddedXMPEnabled(enabled: boolean): Promise<boolean> {
   try {
     const encoderManager = ppro.EncoderManager.getManager() as EncoderManagerExtended;
-    const result = await encoderManager.setEmbeddedXMPEnabled(enabled);
-    return result;
+    return  await encoderManager.setEmbeddedXMPEnabled(enabled);
   } catch (e) {
     log(`Error: ${e}`, "red");
     return false;

--- a/sample-panels/premiere-api/html/src/encoderManager.ts
+++ b/sample-panels/premiere-api/html/src/encoderManager.ts
@@ -16,6 +16,8 @@ import type { EncoderManager, premierepro, Project, ProjectItem } from "@adobe/p
 
 type EncoderManagerExtended = EncoderManager & {
   setEmbeddedXMPEnabled(enabled: boolean): Promise<boolean>;
+  launchEncoder(): Promise<boolean>;
+  startBatchEncode(): Promise<boolean>;
 };
 import { getSelectedProjectItems } from "./projectPanel.js";
 import { log } from "./utils";
@@ -93,7 +95,27 @@ export async function encodeFirstSelectedProjectItem(
 export async function setEmbeddedXMPEnabled(enabled: boolean): Promise<boolean> {
   try {
     const encoderManager = ppro.EncoderManager.getManager() as EncoderManagerExtended;
-    return  await encoderManager.setEmbeddedXMPEnabled(enabled);
+    return await encoderManager.setEmbeddedXMPEnabled(enabled);
+  } catch (e) {
+    log(`Error: ${e}`, "red");
+    return false;
+  }
+}
+
+export async function launchEncoder(): Promise<boolean> {
+  try {
+    const encoderManager = ppro.EncoderManager.getManager() as EncoderManagerExtended;
+    return await encoderManager.launchEncoder();
+  } catch (e) {
+    log(`Error: ${e}`, "red");
+    return false;
+  }
+}
+
+export async function startBatchEncode(): Promise<boolean> {
+  try {
+    const encoderManager = ppro.EncoderManager.getManager() as EncoderManagerExtended;
+    return await encoderManager.startBatchEncode();
   } catch (e) {
     log(`Error: ${e}`, "red");
     return false;

--- a/sample-panels/premiere-api/html/src/encoderManager.ts
+++ b/sample-panels/premiere-api/html/src/encoderManager.ts
@@ -88,37 +88,35 @@ export async function encodeFirstSelectedProjectItem(
 
 
 let embeddedXMPState = false;
-export async function toggleEmbeddedXMP(): Promise<boolean> {
+export async function toggleEmbeddedXMP(): Promise<{ success: boolean; state: boolean }> {
   try {
     embeddedXMPState = !embeddedXMPState;
     const encoderManager = ppro.EncoderManager.getManager();
-    const result = await encoderManager.setEmbeddedXMPEnabled(embeddedXMPState);
-    log(result ? `setEmbeddedXMPEnabled(${embeddedXMPState}) succeeded` : `setEmbeddedXMPEnabled(${embeddedXMPState}) failed`);
-    return result;
+    const success = await encoderManager.setEmbeddedXMPEnabled(embeddedXMPState);
+    return { success, state: embeddedXMPState };
   } catch (e) {
     log(`Error: ${e}`, "red");
-    return false;
+    return { success: false, state: embeddedXMPState };
   }
 }
 
 let sidecarXMPState = false;
-export async function toggleSidecarXMP(): Promise<boolean> {
+export async function toggleSidecarXMP(): Promise<{ success: boolean; state: boolean }> {
   try {
     sidecarXMPState = !sidecarXMPState;
     const encoderManager = ppro.EncoderManager.getManager();
-    const result = await encoderManager.setSidecarXMPEnabled(sidecarXMPState);
-    log(result ? `setSidecarXMPEnabled(${sidecarXMPState}) succeeded` : `setSidecarXMPEnabled(${sidecarXMPState}) failed`);
-    return result;
+    const success = await encoderManager.setSidecarXMPEnabled(sidecarXMPState);
+    return { success, state: sidecarXMPState };
   } catch (e) {
     log(`Error: ${e}`, "red");
-    return false;
+    return { success: false, state: sidecarXMPState };
   }
 }
 
 export async function launchEncoder(): Promise<boolean> {
   try {
     const encoderManager = ppro.EncoderManager.getManager();
-    return await encoderManager.launchEncoder();
+    return encoderManager.launchEncoder();
   } catch (e) {
     log(`Error: ${e}`, "red");
     return false;
@@ -128,7 +126,7 @@ export async function launchEncoder(): Promise<boolean> {
 export async function startBatchEncode(): Promise<boolean> {
   try {
     const encoderManager = ppro.EncoderManager.getManager();
-    return await encoderManager.startBatchEncode();
+    return encoderManager.startBatchEncode();
   } catch (e) {
     log(`Error: ${e}`, "red");
     return false;


### PR DESCRIPTION
1. Adds a sample demonstrating the newly exposed EncoderManager apis setEmbeddedXMPEnabled , launchEncoder, setSidecarXMPEnabled and startBatch in the UXP sample plugin
2. Adds a "Toggle Embedded XMP", "Launch Encoder", "Toggle SidecarXMP" and "Start batch" button under the EncoderManager section in the "New APIs Coming in 26.3 (Beta)" panel
3. Implements toggleEmbeddedXMPEnabled(enabled: boolean), launchEncoder(), toggleSidecarXMPEnabled(enabled: boolean) & startBatch() in encoderManager.ts, calling the API via EncoderManager.getManager()
4. updated types version. 

Testing:
<img width="1063" height="554" alt="Screenshot 2026-05-05 at 2 00 55 PM" src="https://github.com/user-attachments/assets/72760eb5-570a-497c-a402-663d5fb179b3" />

