### PR TITLE
Rewrite root README for clarity and onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,62 +1,150 @@
-# Sample UXP plugins for Premiere
+# Premiere Pro UXP Samples
 
-The Premiere Pro UXP API documentation is available here: <https://developer.adobe.com/premiere-pro/uxp/>.
+A collection of sample plugins for Adobe Premiere Pro built with UXP. Use them as a reference, adapt them in your own projects, or explore them to understand the Premiere Pro UXP API surface. The full API reference is available at [developer.adobe.com/premiere-pro/uxp](https://developer.adobe.com/premiere-pro/uxp/).
 
-## Tools
+**New to UXP plugins?** We recommend starting with the official [**Building your first UXP plugin**](https://developer.adobe.com/premiere-pro/uxp/plugins/) tutorial. It walks through scaffolding a plugin with the UXP Developer Tool and loading it into Premiere Pro. The samples in this repository will be easier to follow afterwards.
 
-- Premiere or Premiere Beta 25.4 or greater
-- UXP Developer Tools 2.2 or greater
+---
 
-### Premiere API
+## Contents
 
-The flagship sample, which exercises the Premiere UXP APIs.
+- [Prerequisites](#prerequisites)
+- [Samples](#samples)
+- [Version compatibility](#version-compatibility)
+- [Getting started](#getting-started)
+- [TypeScript support](#typescript-support)
+- [Linting](#linting)
+- [Frequently asked questions](#frequently-asked-questions)
+- [Additional resources](#additional-resources)
+- [Contributing](#contributing)
+- [License](#license)
 
-We also provide:
+---
 
-#### Metadata Handler
+## Prerequisites
 
-Port of a popular CEP panel developed specifically for film turnovers; the [plugin](https://adobe.com/go/cc_plugins_discover_plugin?pluginId=1836f173&workflow=share) can be installed (free) via Creative Cloud Desktop.
+| Tool                                | Version            | Where to get it                                                                                          |
+| :---------------------------------- | :----------------: | :------------------------------------------------------------------------------------------------------- |
+| **Premiere Pro** (stable or beta)   | `25.2` or newer    | [adobe.com/products/premiere](https://www.adobe.com/products/premiere.html)                              |
+| **UXP Developer Tool** (UDT)        | `2.2` or newer     | Install via [Creative Cloud Desktop](https://creativecloud.adobe.com/apps/download/uxp-developer-tools)  |
+| **Node.js**                         | LTS (`18.x` or newer) | [nodejs.org](https://nodejs.org/)                                                                     |
+| **Code editor**                     | —                  | Visual Studio Code, Cursor, or any editor of your choice                                                 |
 
-#### OAuth workflow example
+Before loading any plugin from UDT, enable **Developer Mode** in Premiere Pro:
 
-Here's everything we know about OAuth workflows in Premiere, which is not much.
+> **Settings → Plugins → Enable developer mode**, then restart Premiere Pro.
 
-## Build
+---
 
-From a command prompt in `sample-panels/premiere-api/html`:
+## Samples
+
+| Sample | Description | Stack | Build required |
+| :--- | :--- | :--- | :--- |
+| [`premiere-api`](./sample-panels/premiere-api/) | A comprehensive reference panel that exercises a broad set of Premiere UXP APIs: projects, sequences, markers, metadata, effects, transitions, keyframes, source monitor, import/export, encoder, transcripts, and project conversion (AAF, FCPXML, OTIO). The recommended starting point when investigating how a specific API behaves. | TypeScript | Yes |
+| [`metadata-handler`](./sample-panels/metadata-handler/) | A production-style workflow panel for managing project item metadata. Supports column-to-column copy and exchange, batch updates with prefix/suffix/sequence numbering, metadata export, and clip marker export. Ported from a popular CEP panel used in film turnover workflows. | JavaScript | No |
+| [`oauth-workflow-sample`](./sample-panels/oauth-workflow-sample/) | An end-to-end example of integrating an OAuth 2.0 authorization-code flow into a Premiere Pro UXP plugin, using Dropbox as the example service. Includes a small Node.js server that brokers the token exchange. | JavaScript + Node.js server | Server only |
+
+### Which sample should I start with?
+
+- **To learn the Premiere UXP API** → [`premiere-api`](./sample-panels/premiere-api/)
+- **To study a complete, production-style workflow** → [`metadata-handler`](./sample-panels/metadata-handler/)
+- **To authenticate against a third-party service** → [`oauth-workflow-sample`](./sample-panels/oauth-workflow-sample/)
+
+---
+
+## Version compatibility
+
+The values below are sourced directly from each sample's `manifest.json` and `package.json`. In the event of a discrepancy, the manifests are authoritative.
+
+| Sample                    | Min Premiere |  `@adobe/premierepro` | Manifest |
+| :------------------------ | :----------: | --------------------: | :------: |
+| `premiere-api`            | `25.1.0`     | `^26.3.0-beta.67`     | `v5`     |
+| `metadata-handler`        | `25.2.0`     | `^26.3.0-beta.54`     | `v5`     |
+| `oauth-workflow-sample`   | `25.2.0`     | —                     | `v5`     |
+
+---
+
+## Getting started
+
+### 1. Clone the repository
 
 ```bash
-npm i
+git clone https://github.com/AdobeDocs/uxp-premiere-pro-samples.git
+cd uxp-premiere-pro-samples
+```
+
+### 2. Build the sample you want to run
+
+Each sample has its own build (or no-build) requirements. Expand the section that applies.
+
+<details>
+<summary><strong><code>premiere-api</code> — TypeScript, requires a build</strong></summary>
+
+```bash
+cd sample-panels/premiere-api/html
+npm install
 npm run build
 ```
 
-The built plugin is in  `/premiere-api/build-html` .
+The compiled plugin is written to `sample-panels/premiere-api/build-html/`. Point UDT at the `manifest.json` inside `build-html/`, not the one in `html/`.
 
-## Load and debug
+</details>
 
-- Launch Premiere (or Premiere Beta).
-- Launch UXP Developer Tools (UDT).
-- Select **Add Plugin**, and navigate to `/premiere-api/build-html/manifest.json`.
+<details>
+<summary><strong><code>metadata-handler</code> — JavaScript, no build required</strong></summary>
 
-![UXP Developer Tool UDT](payloads/UDT_load_panel.png)
+No installation or build step is required. Point UDT directly at `sample-panels/metadata-handler/manifest.json`.
 
-Here's `premiere-api` in Premiere:
+</details>
 
-![UXP Sample Panel](payloads/UXP-sample-panel-loaded.png)
+<details>
+<summary><strong><code>oauth-workflow-sample</code> — JavaScript with a local Node.js server</strong></summary>
 
-## Adding TypeScript Definitions in Visual Studio Code
-
-Install the `@adobe/premierepro` type declaration package. The `premiere-api` and `metadata-handler` sample panels already include this in its dependencies as an example.
-
-```sh
-# For current APIs
-$ npm install -D @adobe/premierepro
-
-# To see what's available in Beta
-$ npm install -D @adobe/premierepro@beta
+```bash
+cd sample-panels/oauth-workflow-sample/server
+npm install
+npm start
 ```
 
-For JavaScript-specific projects: create a `jsconfig.json` file which includes at least the following configuration:
+Point UDT at `sample-panels/oauth-workflow-sample/manifest.json`. You will also need to configure your Dropbox API credentials before first run — see the [sample's README](./sample-panels/oauth-workflow-sample/README.md) for instructions.
+
+</details>
+
+### 3. Load the plugin in Premiere Pro
+
+The loading flow is the same for every sample:
+
+1. Launch Premiere Pro (or Premiere Pro Beta).
+2. Launch the UXP Developer Tool.
+3. Click **Add Plugin** and select the `manifest.json` for the sample.
+4. Click **Load**, or **Load & Watch** to enable automatic reloads while editing source files.
+
+<p align="center">
+  <img src="payloads/UDT_load_panel.png" alt="Loading a panel in UDT" width="720">
+</p>
+
+The panel appears in Premiere Pro under **Window → UXP Plugins**.
+
+<p align="center">
+  <img src="payloads/UXP-sample-panel-loaded.png" alt="Sample panel loaded in Premiere Pro" width="720">
+</p>
+
+---
+
+## TypeScript support
+
+The Premiere Pro UXP APIs ship official TypeScript declarations through the [`@adobe/premierepro`](https://www.npmjs.com/package/@adobe/premierepro) package. Install the channel that suits your project:
+
+```bash
+# Stable APIs
+npm install -D @adobe/premierepro
+
+# Beta APIs (preview of upcoming surface)
+npm install -D @adobe/premierepro@beta
+```
+
+TypeScript projects pick up the declarations automatically. For JavaScript projects that want autocomplete and inline documentation in Visual Studio Code or Cursor, add a `jsconfig.json` at the root of your plugin:
+
 ```json
 {
   "compilerOptions": {
@@ -66,24 +154,113 @@ For JavaScript-specific projects: create a `jsconfig.json` file which includes a
 }
 ```
 
-You can now see and use TypeScript declarations for Premiere Pro's UXP APIs, in Visual Studio Code, either directly in TypeScript projects:
+Autocomplete and inline documentation are then available in both TypeScript and JavaScript projects.
 
-![UXP typescript autocomplete](payloads/ts_def_demo.png)
+<p align="center">
+  <img src="payloads/ts_def_demo.png" alt="TypeScript autocomplete for Premiere UXP APIs" width="720">
+</p>
 
-Or using JSDoc equivalent documentation and tags to add type hints in JavaScript projects:
+<p align="center">
+  <img src="payloads/js_def_demo.png" alt="JSDoc type hints for Premiere UXP APIs in JavaScript" width="720">
+</p>
 
-![UXP JSDoc type hints](payloads/js_def_demo.png)
+---
 
 ## Linting
 
-To lint the `premiere-api` sample code and peform some basic static analysis, you can run:
+The `premiere-api` sample uses the official [`@adobe/eslint-plugin-premierepro`](https://www.npmjs.com/package/@adobe/eslint-plugin-premierepro) plugin to catch common mistakes when calling the Premiere UXP APIs. We recommend adopting the same plugin in your own projects.
 
-```sh
-$ npm run lint
+```bash
+cd sample-panels/premiere-api/html
+npm run lint
 ```
 
-This will print out per-file warnings and/or errors that should be fixed before commiting new features to the repository.
+---
 
-## Transcript definition
+## Frequently asked questions
 
-We have included [Premiere Pro's transcript JSON definition](./sample-panels/premiere-api/html/assets/transcript_format_spec.json), in the `assets` directory, within the `premiere-api` sample plugin.
+<details>
+<summary><strong>My plugin does not appear in Premiere Pro.</strong></summary>
+
+Verify the following:
+
+1. Developer Mode is enabled in Premiere Pro, and Premiere Pro has been restarted since enabling it.
+2. The `host.minVersion` declared in your `manifest.json` is less than or equal to your installed Premiere Pro version.
+3. UDT can detect Premiere Pro in its left-hand pane. If it cannot, restart both applications.
+
+</details>
+
+<details>
+<summary><strong>Where do <code>console.log</code> outputs appear?</strong></summary>
+
+In UDT, locate your loaded plugin and click **Debug**. This opens a Chromium DevTools window attached to your plugin, providing access to the console, network activity, and DOM inspector.
+
+</details>
+
+<details>
+<summary><strong>Are Premiere UXP API calls asynchronous?</strong></summary>
+
+Yes. Most Premiere UXP APIs return Promises and must be awaited (or chained with `.then()`). Failing to await them produces incorrect results and can block the panel UI. The `premiere-api` sample uses `async`/`await` consistently throughout its `src/` modules and serves as a reference for the recommended pattern.
+
+</details>
+
+<details>
+<summary><strong>How do I request file system or network access?</strong></summary>
+
+Declare the required capabilities under `requiredPermissions` in your `manifest.json`:
+
+- The [`oauth-workflow-sample` manifest](./sample-panels/oauth-workflow-sample/manifest.json) demonstrates `network` and `launchProcess` permissions.
+- The [`premiere-api` manifest](./sample-panels/premiere-api/html/manifest.json) demonstrates `localFileSystem` and `clipboard` permissions.
+
+</details>
+
+<details>
+<summary><strong>UDT is not reloading my changes to <code>manifest.json</code>.</strong></summary>
+
+UDT's **Watch** mode only reloads source files. Changes to `manifest.json` require an explicit **Unload** followed by **Load** in UDT.
+
+</details>
+
+<details>
+<summary><strong>Can I combine a UXP panel with a native C++ plugin?</strong></summary>
+
+Yes. See the [Hybrid Plugins](https://developer.adobe.com/premiere-pro/uxp/plugins/hybrid-plugins/) guide in the official documentation.
+
+</details>
+
+<details>
+<summary><strong>Is the Premiere Pro transcript JSON format documented?</strong></summary>
+
+Yes. The full specification is included in this repository at [`sample-panels/premiere-api/html/assets/transcript_format_spec.json`](./sample-panels/premiere-api/html/assets/transcript_format_spec.json).
+
+</details>
+
+---
+
+## Additional resources
+
+- [UXP for Premiere Pro — Introduction](https://developer.adobe.com/premiere-pro/uxp/)
+- [Building your first UXP plugin](https://developer.adobe.com/premiere-pro/uxp/plugins/)
+- [Plugin concepts: panels, commands, manifest](https://developer.adobe.com/premiere-pro/uxp/plugins/concepts/)
+- [Hybrid plugins](https://developer.adobe.com/premiere-pro/uxp/plugins/hybrid-plugins/)
+- [Sharing and distributing plugins](https://developer.adobe.com/premiere-pro/uxp/plugins/distribute/)
+- [`@adobe/premierepro` on npm](https://www.npmjs.com/package/@adobe/premierepro)
+- [`@adobe/eslint-plugin-premierepro` on npm](https://www.npmjs.com/package/@adobe/eslint-plugin-premierepro)
+
+---
+
+## Contributing
+
+Contributions are welcome. Before submitting a pull request, please:
+
+- Review the [contributing guide](./.github/CONTRIBUTING.md).
+- Adhere to the [code of conduct](./CODE_OF_CONDUCT.md).
+- Complete the [pull request template](./.github/PULL_REQUEST_TEMPLATE.md).
+
+Bug reports and feature requests can be filed via [GitHub Issues](https://github.com/AdobeDocs/uxp-premiere-pro-samples/issues).
+
+---
+
+## License
+
+This project is released under the terms of the [LICENSE](./LICENSE). See [COPYRIGHT](./COPYRIGHT) for additional notices.


### PR DESCRIPTION
## Description

Rewrote the root README. The old one was thin on onboarding context, had version info that didn't match the sample manifests, and didn't really tell a developer where to start.

What's new in the README:

- A short tagline at the top, and a callout pointing new devs to the official "Building your first UXP plugin" tutorial before they dig into the samples here.
- A Contents list so people can jump around.
- A Prerequisites table — Premiere, UDT, Node, editor — with links to where to get each, plus the Developer Mode reminder.
- A Samples table with a short description, stack, and whether a build is needed. Followed by a quick "which sample should I start with?" guide.
- A Version compatibility table built from each sample's actual manifest and package.json. Also fixes the old README's claim that Premiere 25.4 was the minimum — the manifests actually say 25.1 / 25.2.
- A Getting started section split into per-sample collapsibles (TS build, no-build JS, OAuth + local server) so devs only see the steps for the sample they picked.
- An FAQ as collapsibles, covering the questions that come up most often: plugin not showing up, where console.log goes, awaiting async calls, requiredPermissions, manifest reload behavior, hybrid plugins, and the transcript format.
- An Additional resources section with links to the official docs, plugin concepts, hybrid plugins, distribution, and the npm packages.

No code changes anywhere — the three sample plugins are untouched.

## Related Issue

No related issue — internal docs improvement.

## Motivation and Context

When a new dev lands on this repo, the old README didn't really help them. It didn't explain where this repo sits relative to the official UXP docs, the version numbers were stale, and there was no FAQ for the stuff people get stuck on. The goal here is to make this repo feel like the "next step after the official tutorial" rather than something parallel to it.

## How Has This Been Tested?

- Rendered the README on GitHub and confirmed the tables, collapsibles, and centered images look right.
- Checked every version number in the compatibility table against the actual manifest.json and package.json for each sample.
- Clicked through the relative links to make sure they all resolve.
- Didn't touch any sample code, so the three plugins still build and load the same as before.

## Screenshots

<!-- Optional: screenshot of the rendered README on GitHub. -->

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html). _(Not required — Adobe employee.)_
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation. _(This is the documentation change.)_
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. _(N/A — docs only.)_
- [x] All new and existing tests passed. _(N/A — no code changed.)_