### PR TITLE
Add example for ClipProjectItem.createSubClipAction

### DIFF
--- a/sample-panels/premiere-api/html/index.html
+++ b/sample-panels/premiere-api/html/index.html
@@ -160,6 +160,10 @@
         <sp-button id="export-aaf">Export as AAF</sp-button>
       </div>
       <div class="section">
+        <h4>Project Panel</h4>
+        <sp-button id="project-panel-create-sub-clips">Create Sub Clips From Selection</sp-button>
+      </div>
+      <div class="section">
         <h4>Source Monitor</h4>
         <sp-button id="set-source-monitor-position">Set Source Monitor Position</sp-button>
       </div>

--- a/sample-panels/premiere-api/html/index.ts
+++ b/sample-panels/premiere-api/html/index.ts
@@ -95,6 +95,7 @@ import {
   getFirstProjectItemColorLabel,
   setFirstProjectItemColorLabel,
   getOriginatingProjectPath,
+  createSubClips,
 } from "./src/projectPanel";
 
 import {
@@ -533,6 +534,23 @@ async function exportAAFClicked() {
     log(`Successfully exported AAF to ${outputFilePath}`);
   } else {
     log(`Failed to export AAF`, "red");
+  }
+}
+
+async function createSubClipsFromSelectionClicked() {
+  const project = await getProject();
+  if (!project) {
+    log(`Failed to get project`, "red");
+    return;
+  }
+
+  try {
+    const subClips = await createSubClips(project);
+    if (subClips.length > 0) {
+      log(`Successfully created sub clip(s): "${subClips.map(subClip => subClip.name).join(', ')}"`);
+    }
+  } catch (error) {
+    log(`Error creating sub clip: ${error}`, "red");
   }
 }
 
@@ -2614,6 +2632,7 @@ window.addEventListener("load", async () => {
   registerClick("has-object-mask", hasObjectMaskClicked);
   registerClick("create-sequence-with-preset-path", createSequenceWithPresetPathClicked);
   registerClick("export-aaf", exportAAFClicked);
+  registerClick("project-panel-create-sub-clips", createSubClipsFromSelectionClicked);
   registerClick("set-source-monitor-position", setSourceMonitorPositionClicked);
   registerClick("query-supported-languages", querySupportedLanguagesClicked);
   registerClick("has-transcript", hasTranscriptClicked);

--- a/sample-panels/premiere-api/html/src/projectPanel.ts
+++ b/sample-panels/premiere-api/html/src/projectPanel.ts
@@ -14,6 +14,7 @@
 
 import type {
   ClipProjectItem,
+  FolderItem,
   premierepro,
   Project,
   ProjectItem,
@@ -145,6 +146,68 @@ export async function createSmartBin(project: Project) {
   }
 
   return success;
+}
+
+export async function createSubClips(project: Project): Promise<ProjectItem[]> {
+  if (!project) {
+    log(`No project found.`, "red");
+    return [];
+  }
+  
+  const selectedItems = await getSelectedProjectItems(project);
+  const subClipsToCreate = selectedItems
+    .reduce((acc, projectItem) => {
+      const clipProjectItem = ppro.ClipProjectItem.cast(projectItem);
+      if (clipProjectItem) {
+        acc.push({
+          clipProjectItem,
+          name: `${projectItem.name} - Sub Clip`,
+          // Each sub clip will be created in the same bin as its original clip.
+          parentBin: projectItem.getParentBin(),
+        });
+      }
+      return acc;
+    }, [] as { clipProjectItem: ClipProjectItem, name: string, parentBin: FolderItem }[]);
+
+  if (subClipsToCreate.length === 0) {
+    log(`Select one or more clips to create sub clip(s) from.`, "red");
+    return [];
+  }
+
+  project.lockedAccess(() => {
+    const actions = subClipsToCreate.map((entry) => {
+      // @ts-expect-error - createSubClipAction is not defined in the type definitions
+      return entry.clipProjectItem.createSubClipAction(
+        entry.name,
+        ppro.TickTime.createWithSeconds(0),
+        ppro.TickTime.createWithSeconds(1),
+        true, // hasHardBoundaries
+        // These are the default values for the options, but we can override them if needed.
+        {
+          takeAudio: true,
+          takeVideo: true,
+        }
+      );
+    });
+
+    project.executeTransaction((compoundAction) => {
+      actions.forEach((action) => {
+        compoundAction.addAction(action);
+      });
+    }, "Create Sub Clips");
+  });
+
+  // Collect the sub clips from the 
+  const subClips: ProjectItem[] = [];
+  for (const entry of subClipsToCreate) {
+    const items = await entry.parentBin.getItems();
+    const subClip = items.find((item) => item.name === entry.name);
+    if (subClip) {
+      subClips.push(subClip);
+    }
+  }
+
+  return subClips;
 }
 
 export async function renameBin(project: Project) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Include a new example for the `ClipProjectItem.createSubClipAction` API which creates a fixed-size sub clip for all selected clips in the project panel. This API was added as of Premiere Beta 26.3.0x85.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
