### PR TITLE
Update types package dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ The values below are sourced directly from each sample's `manifest.json` and `pa
 
 | Sample                    | Min Premiere |  `@adobe/premierepro` | Manifest |
 | :------------------------ | :----------: | --------------------: | :------: |
-| `premiere-api`            | `25.1.0`     | `^26.3.0-beta.67`     | `v5`     |
-| `metadata-handler`        | `25.2.0`     | `^26.3.0-beta.67`     | `v5`     |
+| `premiere-api`            | `25.1.0`     | `^26.3.0-beta.85`     | `v5`     |
+| `metadata-handler`        | `25.2.0`     | `^26.3.0-beta.85`     | `v5`     |
 | `oauth-workflow-sample`   | `25.2.0`     | —                     | `v5`     |
 
 ---

--- a/sample-panels/metadata-handler/package-lock.json
+++ b/sample-panels/metadata-handler/package-lock.json
@@ -9,16 +9,16 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@adobe/premierepro": "^26.3.0-beta.67"
+        "@adobe/premierepro": "^26.3.0-beta.85"
       }
     },
     "node_modules/@adobe/premierepro": {
-      "version": "26.3.0-beta.67",
-      "resolved": "https://registry.npmjs.org/@adobe/premierepro/-/premierepro-26.3.0-beta.67.tgz",
-      "integrity": "sha512-0HiLYPfvoiqxbVtFDpJDu4qnGXXAhzApcexxuMyV1sIhRNhjk/6+7eLurCTrOe9XqirrUX5igSk1SwRP5sT/Qw==",
+      "version": "26.3.0-beta.85",
+      "resolved": "https://registry.npmjs.org/@adobe/premierepro/-/premierepro-26.3.0-beta.85.tgz",
+      "integrity": "sha512-8KPROVceBzD0oKMSSSYgSvlnWVNWp59+GUV2DQMNX5wfDCe/XG+TM6DTf1F4nbrg1ZNt1657piC8PnXCARPGWA==",
       "dev": true,
       "engines": {
-        "node": ">=24.13.0"
+        "node": ">=20.0.0"
       }
     }
   }

--- a/sample-panels/metadata-handler/package.json
+++ b/sample-panels/metadata-handler/package.json
@@ -5,6 +5,6 @@
   "author": "Adobe Inc",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@adobe/premierepro": "^26.3.0-beta.67"
+    "@adobe/premierepro": "^26.3.0-beta.85"
   }
 }

--- a/sample-panels/premiere-api/html/package-lock.json
+++ b/sample-panels/premiere-api/html/package-lock.json
@@ -6,8 +6,8 @@
     "": {
       "devDependencies": {
         "@adobe/cc-ext-uxp-types": "^7.3.1",
-        "@adobe/eslint-plugin-premierepro": "^26.3.0-beta.67",
-        "@adobe/premierepro": "^26.3.0-beta.67",
+        "@adobe/eslint-plugin-premierepro": "^26.3.0-beta.85",
+        "@adobe/premierepro": "^26.3.0-beta.85",
         "@eslint/js": "^9.39.4",
         "@types/node": "^22.10.2",
         "cp-cli": "^2.0.0",
@@ -25,15 +25,15 @@
       "dev": true
     },
     "node_modules/@adobe/eslint-plugin-premierepro": {
-      "version": "26.3.0-beta.67",
-      "resolved": "https://registry.npmjs.org/@adobe/eslint-plugin-premierepro/-/eslint-plugin-premierepro-26.3.0-beta.67.tgz",
-      "integrity": "sha512-yggxTaKVZWLimM0gjGBPaWthji9tNNfDGOuqIJO1cyzqLxd47W9FJaUL4tOGZqP9f6uj1c+rmKpOPWOaqTNVpw==",
+      "version": "26.3.0-beta.85",
+      "resolved": "https://registry.npmjs.org/@adobe/eslint-plugin-premierepro/-/eslint-plugin-premierepro-26.3.0-beta.85.tgz",
+      "integrity": "sha512-xHPLz/s+pTOb52XUZ0N5iLE5yYiMS0tY8cEqdJ6rYKaJYEE1vCEmDp8G5cLLDylZDuFFUwIDw5+aT9ZuWj+t0Q==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/utils": "^8.58.1"
       },
       "peerDependencies": {
-        "@adobe/premierepro": "26.3.0-beta.67",
+        "@adobe/premierepro": "26.3.0-beta.85",
         "@typescript-eslint/parser": "^8.0.0",
         "eslint": "^9.0.0",
         "typescript": ">=5.0.0"
@@ -48,12 +48,12 @@
       }
     },
     "node_modules/@adobe/premierepro": {
-      "version": "26.3.0-beta.67",
-      "resolved": "https://registry.npmjs.org/@adobe/premierepro/-/premierepro-26.3.0-beta.67.tgz",
-      "integrity": "sha512-0HiLYPfvoiqxbVtFDpJDu4qnGXXAhzApcexxuMyV1sIhRNhjk/6+7eLurCTrOe9XqirrUX5igSk1SwRP5sT/Qw==",
+      "version": "26.3.0-beta.85",
+      "resolved": "https://registry.npmjs.org/@adobe/premierepro/-/premierepro-26.3.0-beta.85.tgz",
+      "integrity": "sha512-8KPROVceBzD0oKMSSSYgSvlnWVNWp59+GUV2DQMNX5wfDCe/XG+TM6DTf1F4nbrg1ZNt1657piC8PnXCARPGWA==",
       "dev": true,
       "engines": {
-        "node": ">=24.13.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/sample-panels/premiere-api/html/package.json
+++ b/sample-panels/premiere-api/html/package.json
@@ -10,8 +10,8 @@
   },
   "devDependencies": {
     "@adobe/cc-ext-uxp-types": "^7.3.1",
-    "@adobe/eslint-plugin-premierepro": "^26.3.0-beta.67",
-    "@adobe/premierepro": "^26.3.0-beta.67",
+    "@adobe/eslint-plugin-premierepro": "^26.3.0-beta.85",
+    "@adobe/premierepro": "^26.3.0-beta.85",
     "@eslint/js": "^9.39.4",
     "@types/node": "^22.10.2",
     "cp-cli": "^2.0.0",

--- a/sample-panels/premiere-api/html/src/projectPanel.ts
+++ b/sample-panels/premiere-api/html/src/projectPanel.ts
@@ -176,7 +176,6 @@ export async function createSubClips(project: Project): Promise<ProjectItem[]> {
 
   project.lockedAccess(() => {
     const actions = subClipsToCreate.map((entry) => {
-      // @ts-expect-error - createSubClipAction is not defined in the type definitions
       return entry.clipProjectItem.createSubClipAction(
         entry.name,
         ppro.TickTime.createWithSeconds(0),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Update package versions for @adobe/premierepro and @adobe/eslint-plugin-premierepro to 26.3.0-beta.85.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified no transpilation warnings/errors in `premiere-api` in particular when running `npm run build`.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (updating dependencies and less exciting tasks)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
