### PR TITLE
Add example for ClipProjectItem.getComponentChain

### DIFF
--- a/sample-panels/premiere-api/index.ts
+++ b/sample-panels/premiere-api/index.ts
@@ -97,6 +97,7 @@ import {
   setFirstProjectItemColorLabel,
   getOriginatingProjectPath,
   createSubClips,
+  printSelectedProjectItemComponentChains,
 } from "./src/projectPanel";
 
 import {
@@ -1691,6 +1692,15 @@ async function checkIsDoneAnalyzingForVideoEffectsClicked() {
   log(`Sequence ${sequence.name} is ${isDone ? "done" : "not done"} analyzing for video effects`);
 }
 
+async function printSelectedProjectItemComponentChainsClicked() {
+  const project = await getProject();
+  if (!project) {
+    log("No project found", "red");
+    return;
+  }
+  await printSelectedProjectItemComponentChains(project);
+}
+
 async function getMediaInfoClicked() {
   const project = await getActiveProject();
   if (!project) {
@@ -2799,6 +2809,10 @@ window.addEventListener("load", async () => {
   registerClick(
     "sequence-check-is-done-analyzing-for-video-effects",
     checkIsDoneAnalyzingForVideoEffectsClicked
+  );
+  registerClick(
+    "print-selected-project-item-component-chains",
+    printSelectedProjectItemComponentChainsClicked
   );
 
   //Effects & transitions

--- a/sample-panels/premiere-api/public/index.html
+++ b/sample-panels/premiere-api/public/index.html
@@ -393,6 +393,9 @@
         <sp-button id="rename-first-selected-projectItem">
           Rename First Selected ProjectItem
         </sp-button>
+        <sp-button id="print-selected-project-item-component-chains">
+          Print Selected ProjectItem Component Chains
+        </sp-button>
       </div>
       <div class="section">
         <h4>Properties</h4>

--- a/sample-panels/premiere-api/src/projectPanel.ts
+++ b/sample-panels/premiere-api/src/projectPanel.ts
@@ -779,3 +779,44 @@ export async function getOriginatingProjectPath(project: Project): Promise<strin
     return null;
   }
 }
+
+const mediaTypeToString = (mediaType: number): string => {
+  switch (mediaType) {
+    case ppro.Constants.MediaType.VIDEO:
+      return "VIDEO";
+    case ppro.Constants.MediaType.AUDIO:
+      return "AUDIO";
+  }
+};
+
+/**
+ * Gets the selected entries in the Project Panel and, for each ClipProjectItem,
+ * prints whether or not there is a component chain for each media type.
+ *
+ * @param project - The project to print the component chains for
+ */
+export async function printSelectedProjectItemComponentChains(project: Project): Promise<void> {
+  try {
+    const projectItems = await getSelectedProjectItems(project);
+    if (projectItems.length === 0) {
+      log("No project items selected", "red");
+      return;
+    }
+
+    for (const projectItem of projectItems) {
+      const clipProjectItem = ppro.ClipProjectItem.cast(projectItem);
+      if (!clipProjectItem) {
+        continue;
+      }
+
+      for (const mediaType of [ppro.Constants.MediaType.VIDEO, ppro.Constants.MediaType.AUDIO]) {
+        const componentChain = await clipProjectItem.getComponentChain(mediaType);
+        if (componentChain) {
+          log(`${projectItem.name} has a component chain for ${mediaTypeToString(mediaType)}`);
+        }
+      }
+    }
+  } catch (error) {
+    log(`Error printing has component chains: ${error}`, "red");
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Add a _really_ basic example showing how to fetch the component chain for ClipProjectItems. Working with effects (audio/video components and params, etc.) more directly can be seen in the `effects.ts` file.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Adding an example to help cover more of the API usage.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested via UDT against the latest build of Premiere

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
