### PR TITLE
feat(premiere-api): Add WorkAreaUtils example

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The values below are sourced directly from each sample's `manifest.json` and `pa
 
 | Sample                    | Min Premiere |  `@adobe/premierepro` | Manifest |
 | :------------------------ | :----------: | --------------------: | :------: |
-| `premiere-api`            | `25.1.0`     | `^26.5.0-beta.8`      | `v5`     |
+| `premiere-api`            | `25.1.0`     | `^26.5.0-beta.29`     | `v5`     |
 | `metadata-handler`        | `25.2.0`     | `^26.3.0`             | `v5`     |
 | `oauth-workflow-sample`   | `25.2.0`     | —                     | `v5`     |
 

--- a/sample-panels/premiere-api/index.ts
+++ b/sample-panels/premiere-api/index.ts
@@ -217,6 +217,13 @@ import {
   exportAsFinalCutProXML,
   exportAsOpenTimelineIO,
 } from "./src/projectConverter";
+import {
+  getWorkAreaInPoint,
+  getWorkAreaOutPoint,
+  setWorkAreaInOutPoints,
+  setWorkAreaInPoint,
+  setWorkAreaOutPoint
+} from "./src/workAreaUtils";
 
 import { logHostBackgroundColor, logHostInfo } from "./src/uxpHost";
 
@@ -400,6 +407,88 @@ async function purgeMediaCacheClicked() {
   } else {
     log("Failed to purge media cache", "red");
   }
+}
+
+async function getWorkAreaInPointClicked() {
+  const project = await getProject();
+  if (!project) {
+    log(`Failed to get project`, "red");
+    return;
+  }
+
+  const sequence = await project.getActiveSequence();
+  if (!sequence) {
+    log(`Failed to get active sequence`, "red");
+    return;
+  }
+
+  const workAreaInPoint = getWorkAreaInPoint(sequence);
+  log(`Sequence work area in point: ${workAreaInPoint.seconds} seconds`);
+}
+
+async function getWorkAreaOutPointClicked() {
+  const project = await getProject();
+  if (!project) {
+    log(`Failed to get project`, "red");
+    return;
+  }
+
+  const sequence = await project.getActiveSequence();
+  if (!sequence) {
+    log(`Failed to get active sequence`, "red");
+    return;
+  }
+
+  const workAreaOutPoint = getWorkAreaOutPoint(sequence);
+  log(`Sequence work area out point: ${workAreaOutPoint.seconds} seconds`);
+}
+
+async function setWorkAreaInPointClicked() {
+  const project = await getProject();
+  if (!project) {
+    log(`Failed to get project`, "red");
+    return;
+  }
+
+  const sequence = await project.getActiveSequence();
+  if (!sequence) {
+    log(`Failed to get active sequence`, "red");
+    return;
+  }
+
+  setWorkAreaInPoint(sequence);
+}
+
+async function setWorkAreaOutPointClicked() {
+  const project = await getProject();
+  if (!project) {
+    log(`Failed to get project`, "red");
+    return;
+  }
+
+  const sequence = await project.getActiveSequence();
+  if (!sequence) {
+    log(`Failed to get active sequence`, "red");
+    return;
+  }
+
+  setWorkAreaOutPoint(sequence);
+}
+
+async function setWorkAreaInOutPointsClicked() {
+  const project = await getProject();
+  if (!project) {
+    log(`Failed to get project`, "red");
+    return;
+  }
+
+  const sequence = await project.getActiveSequence();
+  if (!sequence) {
+    log(`Failed to get active sequence`, "red");
+    return;
+  }
+
+  setWorkAreaInOutPoints(sequence);
 }
 
 /* 26.3.0 button events */
@@ -2697,6 +2786,11 @@ window.addEventListener("load", async () => {
   /* 26.5.0 button events registering */
   registerClick("media-manager-purge-media-cache", purgeMediaCacheClicked);
   registerClick("log-host-background-color", logHostBackgroundColorClicked);
+  registerClick("workareautils-get-work-area-in-point", getWorkAreaInPointClicked);
+  registerClick("workareautils-get-work-area-out-point", getWorkAreaOutPointClicked);
+  registerClick("workareautils-set-work-area-in-point", setWorkAreaInPointClicked);
+  registerClick("workareautils-set-work-area-out-point", setWorkAreaOutPointClicked);
+  registerClick("workareautils-set-work-area-in-out-points", setWorkAreaInOutPointsClicked);
 
   /* 26.3.0 button events registering */
   registerClick("set-audio-track-name", setAudioTrackNameClicked);

--- a/sample-panels/premiere-api/package-lock.json
+++ b/sample-panels/premiere-api/package-lock.json
@@ -6,8 +6,8 @@
     "": {
       "devDependencies": {
         "@adobe/cc-ext-uxp-types": "^7.3.1",
-        "@adobe/eslint-plugin-premierepro": "^26.5.0-beta.8",
-        "@adobe/premierepro": "^26.5.0-beta.8",
+        "@adobe/eslint-plugin-premierepro": "^26.5.0-beta.29",
+        "@adobe/premierepro": "^26.5.0-beta.29",
         "@eslint/js": "^9.39.4",
         "@types/node": "^22.10.2",
         "concurrently": "^9.2.1",
@@ -25,15 +25,15 @@
       "dev": true
     },
     "node_modules/@adobe/eslint-plugin-premierepro": {
-      "version": "26.5.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@adobe/eslint-plugin-premierepro/-/eslint-plugin-premierepro-26.5.0-beta.8.tgz",
-      "integrity": "sha512-YSGMtBzdpshquaxE2PXrOKvwu1iLONcsqblHhcsrKs+u9A3phlUPKtk5g787Bd7Un+/L9ePu5aCNVUxcKltL3Q==",
+      "version": "26.5.0-beta.29",
+      "resolved": "https://registry.npmjs.org/@adobe/eslint-plugin-premierepro/-/eslint-plugin-premierepro-26.5.0-beta.29.tgz",
+      "integrity": "sha512-OOS37ANv2tQxRaTUM9XlAGLwSb0UH9cCZgggPuRsB0ldTF8GlhWxvyFD37Oi2ZdAjXGCKodU1olbh03nmZzXnQ==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/utils": "^8.58.1"
       },
       "peerDependencies": {
-        "@adobe/premierepro": "26.5.0-beta.8",
+        "@adobe/premierepro": "26.5.0-beta.29",
         "@typescript-eslint/parser": "^8.0.0",
         "eslint": "^9.0.0",
         "typescript": ">=5.0.0"
@@ -48,9 +48,9 @@
       }
     },
     "node_modules/@adobe/premierepro": {
-      "version": "26.5.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@adobe/premierepro/-/premierepro-26.5.0-beta.8.tgz",
-      "integrity": "sha512-Ku/az2VthbiGh8CF63QLNMmrISZaFz/feIb8NgoCMm6oNgV+qWKn9kgUFdHLPtQvaVIZHppzwiDri/B1eQdyPA==",
+      "version": "26.5.0-beta.29",
+      "resolved": "https://registry.npmjs.org/@adobe/premierepro/-/premierepro-26.5.0-beta.29.tgz",
+      "integrity": "sha512-lE9PB3b4RNlQztkGsZde11v2Lmtx5wxXrmaX23WPQcstEnoL//mEm8nd6hcBjCpW+zEAozgjBg5cVtMHy6CtkA==",
       "dev": true,
       "engines": {
         "node": ">=20.0.0"

--- a/sample-panels/premiere-api/package.json
+++ b/sample-panels/premiere-api/package.json
@@ -9,8 +9,8 @@
   },
   "devDependencies": {
     "@adobe/cc-ext-uxp-types": "^7.3.1",
-    "@adobe/eslint-plugin-premierepro": "^26.5.0-beta.8",
-    "@adobe/premierepro": "^26.5.0-beta.8",
+    "@adobe/eslint-plugin-premierepro": "^26.5.0-beta.29",
+    "@adobe/premierepro": "^26.5.0-beta.29",
     "@eslint/js": "^9.39.4",
     "@types/node": "^22.10.2",
     "concurrently": "^9.2.1",

--- a/sample-panels/premiere-api/public/index.html
+++ b/sample-panels/premiere-api/public/index.html
@@ -131,6 +131,14 @@
         <h4>UXP Host Environment</h4>
         <sp-button id="log-host-background-color">Log Host Background Color</sp-button>
       </div>
+      <div class="section">
+        <h4>WorkAreaUtils</h4>
+        <sp-button id="workareautils-get-work-area-in-point">Get Work Area In Point</sp-button>
+        <sp-button id="workareautils-get-work-area-out-point">Get Work Area Out Point</sp-button>
+        <sp-button id="workareautils-set-work-area-in-point">Set Work Area In Point</sp-button>
+        <sp-button id="workareautils-set-work-area-out-point">Set Work Area Out Point</sp-button>
+        <sp-button id="workareautils-set-work-area-in-out-points">Set Work Area In and Out Points</sp-button>
+      </div>
 
       <h3>&#x2728; New APIs Coming in 26.3 (Beta)</h3>
       <div class="section">

--- a/sample-panels/premiere-api/src/workAreaUtils.ts
+++ b/sample-panels/premiere-api/src/workAreaUtils.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ *
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import type { premierepro, Sequence, TickTime } from "@adobe/premierepro";
+
+import { log } from "./utils";
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const ppro = require("premierepro") as premierepro;
+
+/**
+ * Gets the in point of the work area for a sequence.
+ * @param sequence - The sequence to get the work area in point for.
+ * @returns The in point of the work area for the sequence.
+ */
+export function getWorkAreaInPoint(sequence: Sequence): TickTime {
+  // @ts-expect-error - WorkAreaUtils is not available in the type definitions
+  return ppro.WorkAreaUtils.getWorkAreaInPoint(sequence);
+}
+
+/**
+ * Gets the out point of the work area for a sequence.
+ * @param sequence - The sequence to get the work area out point for.
+ * @returns The out point of the work area for the sequence.
+ */
+export function getWorkAreaOutPoint(sequence: Sequence): TickTime {
+  // @ts-expect-error - WorkAreaUtils is not available in the type definitions
+  return ppro.WorkAreaUtils.getWorkAreaOutPoint(sequence);
+}
+
+/**
+ * Sets the in point of the work area for a sequence.
+ * @param sequence - The sequence to set the work area in point for.
+ * @param [inPoint=ppro.TickTime.TIME_ZERO] - The in point to set for the work area.
+ * @returns True if the in point was set successfully, false otherwise.
+ */
+export function setWorkAreaInPoint(
+  sequence: Sequence,
+  inPoint: TickTime = ppro.TickTime.TIME_ZERO
+): boolean {
+  // @ts-expect-error - WorkAreaUtils is not available in the type definitions
+  const success = ppro.WorkAreaUtils.setWorkAreaInPoint(sequence, inPoint);
+  if (success) {
+    log(`Sequence work area in point set to ${inPoint.seconds} seconds`, "green");
+  } else {
+    log(`Failed to set sequence work area in point`, "red");
+  }
+  return success;
+}
+
+/**
+ * Sets the out point of the work area for a sequence.
+ * @param sequence - The sequence to set the work area out point for.
+ * @param [outPoint=ppro.TickTime.TIME_MAX] - The out point to set for the work area.
+ * @returns True if the out point was set successfully, false otherwise.
+ */
+export function setWorkAreaOutPoint(
+  sequence: Sequence,
+  outPoint: TickTime = ppro.TickTime.TIME_MAX
+): boolean {
+  // @ts-expect-error - WorkAreaUtils is not available in the type definitions
+  const success = ppro.WorkAreaUtils.setWorkAreaOutPoint(sequence, outPoint);
+  if (success) {
+    log(`Sequence work area out point set to ${outPoint.seconds} seconds`, "green");
+  } else {
+    log(`Failed to set sequence work area out point`, "red");
+  }
+  return success;
+}
+
+/**
+ * Sets the in and out points of the work area for a sequence.
+ * @param sequence - The sequence to set the work area in and out points for.
+ * @param [inPoint=ppro.TickTime.TIME_ONE_SECOND] - The in point to set for the work area.
+ * @param [outPoint=ppro.TickTime.createWithSeconds(10)] - The out point to set for the work area.
+ * @returns True if the in and out points were set successfully, false otherwise.
+ */
+export function setWorkAreaInOutPoints(
+  sequence: Sequence,
+  inPoint: TickTime = ppro.TickTime.TIME_ONE_SECOND,
+  outPoint: TickTime = ppro.TickTime.createWithSeconds(10),
+): boolean {
+  // @ts-expect-error - WorkAreaUtils is not available in the type definitions
+  const success = ppro.WorkAreaUtils.setWorkAreaInOutPoints(sequence, inPoint, outPoint);
+  if (success) {
+    log(`Sequence work area in and out points set to ${inPoint.seconds} seconds and ${outPoint.seconds} seconds`, "green");
+  } else {
+    log(`Failed to set sequence work area in and out points`, "red");
+  }
+  return success;
+}

--- a/sample-panels/premiere-api/src/workAreaUtils.ts
+++ b/sample-panels/premiere-api/src/workAreaUtils.ts
@@ -24,7 +24,6 @@ const ppro = require("premierepro") as premierepro;
  * @returns The in point of the work area for the sequence.
  */
 export function getWorkAreaInPoint(sequence: Sequence): TickTime {
-  // @ts-expect-error - WorkAreaUtils is not available in the type definitions
   return ppro.WorkAreaUtils.getWorkAreaInPoint(sequence);
 }
 
@@ -34,7 +33,6 @@ export function getWorkAreaInPoint(sequence: Sequence): TickTime {
  * @returns The out point of the work area for the sequence.
  */
 export function getWorkAreaOutPoint(sequence: Sequence): TickTime {
-  // @ts-expect-error - WorkAreaUtils is not available in the type definitions
   return ppro.WorkAreaUtils.getWorkAreaOutPoint(sequence);
 }
 
@@ -48,7 +46,6 @@ export function setWorkAreaInPoint(
   sequence: Sequence,
   inPoint: TickTime = ppro.TickTime.TIME_ZERO
 ): boolean {
-  // @ts-expect-error - WorkAreaUtils is not available in the type definitions
   const success = ppro.WorkAreaUtils.setWorkAreaInPoint(sequence, inPoint);
   if (success) {
     log(`Sequence work area in point set to ${inPoint.seconds} seconds`, "green");
@@ -68,7 +65,6 @@ export function setWorkAreaOutPoint(
   sequence: Sequence,
   outPoint: TickTime = ppro.TickTime.TIME_MAX
 ): boolean {
-  // @ts-expect-error - WorkAreaUtils is not available in the type definitions
   const success = ppro.WorkAreaUtils.setWorkAreaOutPoint(sequence, outPoint);
   if (success) {
     log(`Sequence work area out point set to ${outPoint.seconds} seconds`, "green");
@@ -90,7 +86,6 @@ export function setWorkAreaInOutPoints(
   inPoint: TickTime = ppro.TickTime.TIME_ONE_SECOND,
   outPoint: TickTime = ppro.TickTime.createWithSeconds(10),
 ): boolean {
-  // @ts-expect-error - WorkAreaUtils is not available in the type definitions
   const success = ppro.WorkAreaUtils.setWorkAreaInOutPoints(sequence, inPoint, outPoint);
   if (success) {
     log(`Sequence work area in and out points set to ${inPoint.seconds} seconds and ${outPoint.seconds} seconds`, "green");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adding an example of using the new WorkAreaUtils APIs added in Premiere Beta 26.5.0, build 29.

Bumping the @adobe/premierepro and @adobe/eslint-plugin-premierepro packages for the premiere-api sample panel as well.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<img width="480" height="597" alt="image" src="https://github.com/user-attachments/assets/a9a0cb3e-766c-4938-b069-0d878122078b" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
