### PR TITLE
fix(premiere-api): Replace deprecated Media properties with functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The values below are sourced directly from each sample's `manifest.json` and `pa
 
 | Sample                    | Min Premiere |  `@adobe/premierepro` | Manifest |
 | :------------------------ | :----------: | --------------------: | :------: |
-| `premiere-api`            | `25.1.0`     | `^26.5.0-beta.29`     | `v5`     |
+| `premiere-api`            | `25.1.0`     | `^26.5.0-beta.59`     | `v5`     |
 | `metadata-handler`        | `25.2.0`     | `^26.3.0`             | `v5`     |
 | `oauth-workflow-sample`   | `25.2.0`     | —                     | `v5`     |
 

--- a/sample-panels/premiere-api/package-lock.json
+++ b/sample-panels/premiere-api/package-lock.json
@@ -6,8 +6,8 @@
     "": {
       "devDependencies": {
         "@adobe/cc-ext-uxp-types": "^7.3.1",
-        "@adobe/eslint-plugin-premierepro": "^26.5.0-beta.29",
-        "@adobe/premierepro": "^26.5.0-beta.29",
+        "@adobe/eslint-plugin-premierepro": "^26.5.0-beta.59",
+        "@adobe/premierepro": "^26.5.0-beta.59",
         "@eslint/js": "^9.39.4",
         "@types/node": "^22.10.2",
         "concurrently": "^9.2.1",
@@ -25,15 +25,15 @@
       "dev": true
     },
     "node_modules/@adobe/eslint-plugin-premierepro": {
-      "version": "26.5.0-beta.29",
-      "resolved": "https://registry.npmjs.org/@adobe/eslint-plugin-premierepro/-/eslint-plugin-premierepro-26.5.0-beta.29.tgz",
-      "integrity": "sha512-OOS37ANv2tQxRaTUM9XlAGLwSb0UH9cCZgggPuRsB0ldTF8GlhWxvyFD37Oi2ZdAjXGCKodU1olbh03nmZzXnQ==",
+      "version": "26.5.0-beta.59",
+      "resolved": "https://registry.npmjs.org/@adobe/eslint-plugin-premierepro/-/eslint-plugin-premierepro-26.5.0-beta.59.tgz",
+      "integrity": "sha512-CkfbzwP1LgVTux3kiLTgmcj2flSTeEit9UWnmvHsqooyNzHVRKFiV3TGEo16aXOxDj6Ya7zRl9B0A17/bGkE7Q==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/utils": "^8.58.1"
       },
       "peerDependencies": {
-        "@adobe/premierepro": "26.5.0-beta.29",
+        "@adobe/premierepro": "26.5.0-beta.59",
         "@typescript-eslint/parser": "^8.0.0",
         "eslint": "^9.0.0",
         "typescript": ">=5.0.0"
@@ -48,9 +48,9 @@
       }
     },
     "node_modules/@adobe/premierepro": {
-      "version": "26.5.0-beta.29",
-      "resolved": "https://registry.npmjs.org/@adobe/premierepro/-/premierepro-26.5.0-beta.29.tgz",
-      "integrity": "sha512-lE9PB3b4RNlQztkGsZde11v2Lmtx5wxXrmaX23WPQcstEnoL//mEm8nd6hcBjCpW+zEAozgjBg5cVtMHy6CtkA==",
+      "version": "26.5.0-beta.59",
+      "resolved": "https://registry.npmjs.org/@adobe/premierepro/-/premierepro-26.5.0-beta.59.tgz",
+      "integrity": "sha512-J9llyrakYaoNuRkMeWu/4GnLGPM9784A58QXxJxEpNTVIyj1PJlyl4BkOtnLVLrZUsNQoNjySSYQfX24GZLAog==",
       "dev": true,
       "engines": {
         "node": ">=20.0.0"

--- a/sample-panels/premiere-api/package.json
+++ b/sample-panels/premiere-api/package.json
@@ -9,8 +9,8 @@
   },
   "devDependencies": {
     "@adobe/cc-ext-uxp-types": "^7.3.1",
-    "@adobe/eslint-plugin-premierepro": "^26.5.0-beta.29",
-    "@adobe/premierepro": "^26.5.0-beta.29",
+    "@adobe/eslint-plugin-premierepro": "^26.5.0-beta.59",
+    "@adobe/premierepro": "^26.5.0-beta.59",
     "@eslint/js": "^9.39.4",
     "@types/node": "^22.10.2",
     "concurrently": "^9.2.1",

--- a/sample-panels/premiere-api/src/projectPanel.ts
+++ b/sample-panels/premiere-api/src/projectPanel.ts
@@ -626,8 +626,8 @@ export async function getMediaInfo(project: Project) {
       log("Failed to access media");
       return null;
     }
-    const start = await media.start;
-    const duration = await media.duration;
+    const start = media.getStart();
+    const duration = media.getDuration();
     return {
       name: clipProjectItem.name,
       start: start.seconds,
@@ -652,7 +652,7 @@ export async function setMediaStart(project: Project) {
       log("Failed to access media");
       return false;
     }
-    const duration = await media.duration;
+    const duration = media.getDuration();
     if (duration < ppro.TickTime.TIME_ONE_SECOND) {
       log("Media Duration is smaller than 1 second");
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The `Media.duration` and `Media.start` _async_ properties are being deprecated in favor of _sync_ function equivalents. Update the ProjectPanel samples to use the sync function replacements.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<img width="480" height="597" alt="image" src="https://github.com/user-attachments/assets/e6b3317b-c2d8-46f3-ace6-a585ad8bb9a9" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
